### PR TITLE
Rework ruff noqa linting ignores

### DIFF
--- a/harvester/aws/sqs.py
+++ b/harvester/aws/sqs.py
@@ -104,8 +104,7 @@ class ZipFileEventMessage:
             _ = self.zip_file_identifier
         except (ValueError, AttributeError, ParserError) as exc:
             message = f"Invalid SQS Message, reason: '{exc}', message: {self.raw}"
-            # ruff: noqa: TRY400
-            logger.error(message)
+            logger.error(message)  # noqa: TRY400
             raise MessageValidationError(message) from exc
 
 

--- a/harvester/config.py
+++ b/harvester/config.py
@@ -29,8 +29,10 @@ class Config:
         raise AttributeError(message)
 
 
-# ruff: noqa: FBT001
-def configure_logger(logger: logging.Logger, verbose: bool) -> str:
+def configure_logger(
+    logger: logging.Logger,
+    verbose: bool,  # noqa: FBT001
+) -> str:
     if verbose:
         logging.basicConfig(
             format="%(asctime)s %(levelname)s %(name)s.%(funcName)s() line %(lineno)d: "

--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -12,5 +12,4 @@ class FGDC(XMLSourceRecord):
     """FGDC metadata format SourceRecord class."""
 
     metadata_format: Literal["fgdc"] = field(default="fgdc")
-    # ruff: noqa: TD002,TD003,FIX002
-    # TODO: define namespace map for FGDC files
+    # TODO: define namespace map for FGDC files # noqa: TD002,TD003,FIX002

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# ruff: noqa: N802
+# ruff: noqa: N802, S301
 import json
 from unittest.mock import patch
 
@@ -127,7 +127,6 @@ def valid_sqs_message_deleted_dict():
 @pytest.fixture
 def valid_sqs_message_deleted_instance() -> ZipFileEventMessage:
     with open("tests/fixtures/sqs/valid_deleted_message.json") as f:
-        # ruff: noqa: S301
         return ZipFileEventMessage(json.load(f))
 
 
@@ -140,7 +139,6 @@ def valid_sqs_message_created_dict():
 @pytest.fixture
 def valid_sqs_message_created_instance() -> ZipFileEventMessage:
     with open("tests/fixtures/sqs/valid_created_message.json") as f:
-        # ruff: noqa: S301
         return ZipFileEventMessage(json.load(f))
 
 

--- a/tests/test_aws/test_sqs.py
+++ b/tests/test_aws/test_sqs.py
@@ -157,8 +157,7 @@ def test_sqsclient_get_next_valid_message_handle_validation_error_success(
     # assert a valid one is retrieved after an invalid on skipped
     assert message is not None
     # assert method was called twice in total
-    # ruff: noqa: PLR2004
-    assert mock_boto3_sqs_client.receive_message.call_count == 2
+    assert mock_boto3_sqs_client.receive_message.call_count == 2  # noqa: PLR2004
     # assert error was logged
     assert "Invalid SQS Message" in caplog.text
 
@@ -178,8 +177,7 @@ def test_sqsclient_get_valid_messages_iter_skip_and_yield_success(
     ]
     sqs_client = SQSClient(mocked_sqs_topic_name)
     messages = list(sqs_client.get_valid_messages_iter())
-    # ruff: noqa: PLR2004
-    assert len(messages) == 2
+    assert len(messages) == 2  # noqa: PLR2004
     assert "Invalid SQS Message" in caplog.text
 
 

--- a/tests/test_records/test_iso19139.py
+++ b/tests/test_records/test_iso19139.py
@@ -1,9 +1,10 @@
+# ruff: noqa: SLF001
+
 from unittest.mock import patch
 
 from harvester.records.record import XMLSourceRecord
 
 
-# ruff: noqa: SLF001
 def test_iso19139_field_dct_title_s_one_returned(valid_mit_iso19139_source_record):
     assert (
         valid_mit_iso19139_source_record._dct_title_s()


### PR DESCRIPTION
### Purpose and background context
When ignoring a linting rule, prefer using `# noqa: XXX` inline vs `# ruff: noqa: XXX` within the file, as this will be applied globally.

Note, that `# ruff: noqa: XXX,YYY` at the _top_ of a file still can be useful, when it's determined it's okay to skip those rules for the entire file (e.g. tests).

See this thread, https://github.com/MITLibraries/geo-harvester/pull/16#discussion_r1419443836.

### How can a reviewer manually see the effects of these changes?
```shell
make lint
```

Should still pass lint checks.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes

