### PR TITLE
Set gbl_suppressed_b from SourceRecord event

### DIFF
--- a/harvester/harvest/__init__.py
+++ b/harvester/harvest/__init__.py
@@ -86,18 +86,12 @@ class Harvester(ABC):
         for record in records:
             message = f"Record {record.identifier}: normalizing source record"
             logger.debug(message)
-            # WIP: even for deleted records, we likely WILL still normalize such that we
-            # have a record to provide Transmog where 'gbl_suppressed_b=True' and and
-            # pipeline can remove from TIMDEX.
-            if record.source_record.event == "deleted":
-                yield record
-            else:
-                try:
-                    record.normalized_record = record.source_record.normalize()
-                except Exception as exc:  # noqa: BLE001
-                    record.exception_stage = "normalize_source_records"
-                    record.exception = exc
-                yield record
+            try:
+                record.normalized_record = record.source_record.normalize()
+            except Exception as exc:  # noqa: BLE001
+                record.exception_stage = "normalize_source_records"
+                record.exception = exc
+            yield record
 
     def update_public_cdn_bucket(self, records: Iterator[Record]) -> Iterator[Record]:
         """Write OR delete source and normalized metadata from S3:CDN:Public.

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -447,6 +447,21 @@ class SourceRecord:
             if subject.lower().strip() in theme_list
         ]
 
+    def _gbl_suppressed_b(self) -> bool:
+        """Shared field method: gbl_suppressed_b
+
+        For MITAardvark records, this field is used to indicate if the record should be
+        considered deleted, and therefore will be removed from downstream discovery layers
+        like TIMDEX.
+
+        The boolean value is determined by the SourceRecord.event:
+            - "created" = False (record is not suppressed)
+            - "deleted" = True (record is suppressed)
+        """
+        if self.event == "deleted":
+            return True
+        return False
+
 
 @define
 class XMLSourceRecord(SourceRecord):

--- a/tests/test_harvest/test_harvester.py
+++ b/tests/test_harvest/test_harvester.py
@@ -124,7 +124,7 @@ def test_harvester_step_get_source_records(caplog, generic_harvester_class):
         assert harvester.processed_records_count == 1
 
 
-def test_harvester_step_normalize_source_records_deleted_record(
+def test_harvester_step_normalize_source_records_deleted_record_set_gbl_suppressed(
     caplog, generic_harvester_class, records_for_normalize
 ):
     caplog.set_level("DEBUG")
@@ -132,7 +132,7 @@ def test_harvester_step_normalize_source_records_deleted_record(
     records_for_normalize[0].source_record.event = "deleted"
     records = harvester.normalize_source_records(records_for_normalize)
     record = next(records)
-    assert record.normalized_record is None
+    assert record.normalized_record.gbl_suppressed_b
 
 
 def test_harvester_step_normalize_source_records_created_record_normalized_success(


### PR DESCRIPTION
### Purpose and background context
Small PR to add a shared field method to set boolean field `gbl_suppressed_b`.  We have opted to use this Aardvark boolean field to represent if a record is deleted, which we know during normalization by virtue of the `SourceRecord.event` field which is either `created` or `deleted`.

### How can a reviewer manually see the effects of these changes?
Should be readily apparent from the [updated test](https://github.com/MITLibraries/geo-harvester/compare/GDT-86-iso19139-all-fields...GDT-86-normalize-deleted-records?expand=1#diff-deda2129435dcf50987b4327aa3c3536d398262652eb159982daf9d0b748975cR127-R135) which now does not expect the normalization to be skipped, but instead `gbl_suppressed_b == True` to be set.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-86

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

