### PR TITLE
Send EventBridge Events for MIT Harvests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ ruff = "*"
 ipython = "*"
 moto = "*"
 types-python-dateutil = "*"
-boto3-stubs = {version = "*", extras = ["eventbridge", "s3", "sqs"]}
+boto3-stubs = {version = "*", extras = ["events", "s3", "sqs"]}
 lxml-stubs = "*"
 freezegun = "*"
 types-jsonschema = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b263412bd4abaa4bee0c6e6f70246e5f730c01aee9d64d3e22b9b7b36d89909a"
+            "sha256": "5a649604b3048629f827de7a5ff64c7b9fe4111b819402483a1f2cb9620ec5a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:970fd9f9f522eb48f3cd5574e927b369279ebf5bcf0f2fae5ed9cc6306e58558",
-                "sha256:aad3f305fe3cd4f2bba545c9580cd460c366af56a8aabb6094528dd32317f8d2"
+                "sha256:111d6ba8e54249c7c163fc18b5fdef0faebdf5ba01be48490527178fd2865a6e",
+                "sha256:e165722c2924decd488bf0cd912dee2296d1d219a55be5dd9c93f2967b57c4e8"
             ],
             "index": "pypi",
-            "version": "==1.34.2"
+            "version": "==1.34.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:655b1ea2a5d7b989a0eb6006c16137f785bc7334f31378115668c4be5d4b00eb",
-                "sha256:8a9f4ad438ba814b9b7a22b24de3004f8aa232e7ae86e0087aea4d7792dc3a2a"
+                "sha256:c339876859bddfc38de9d5409458eaab0ae703da867a3b6474a986bf7db7d967",
+                "sha256:eb2adcde8119f715bc7f6c1a991a962700df1b34bba595056b3be55ffa855e82"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.2"
+            "version": "==1.34.5"
         },
         "certifi": {
             "hashes": [
@@ -90,101 +90,102 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3",
-                "sha256:075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d",
-                "sha256:081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a",
-                "sha256:0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120",
-                "sha256:0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305",
-                "sha256:0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287",
-                "sha256:0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23",
-                "sha256:120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52",
-                "sha256:1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f",
-                "sha256:141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4",
-                "sha256:14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584",
-                "sha256:1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f",
-                "sha256:17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693",
-                "sha256:1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef",
-                "sha256:1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5",
-                "sha256:23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02",
-                "sha256:25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc",
-                "sha256:2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7",
-                "sha256:303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da",
-                "sha256:3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a",
-                "sha256:3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40",
-                "sha256:411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8",
-                "sha256:42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd",
-                "sha256:46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601",
-                "sha256:48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c",
-                "sha256:48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be",
-                "sha256:4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2",
-                "sha256:4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c",
-                "sha256:4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129",
-                "sha256:4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc",
-                "sha256:4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2",
-                "sha256:4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1",
-                "sha256:4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7",
-                "sha256:50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d",
-                "sha256:50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477",
-                "sha256:53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d",
-                "sha256:5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e",
-                "sha256:56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7",
-                "sha256:578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2",
-                "sha256:57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574",
-                "sha256:57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf",
-                "sha256:5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b",
-                "sha256:5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98",
-                "sha256:64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12",
-                "sha256:65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42",
-                "sha256:6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35",
-                "sha256:690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d",
-                "sha256:6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce",
-                "sha256:704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d",
-                "sha256:71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f",
-                "sha256:71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db",
-                "sha256:7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4",
-                "sha256:8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694",
-                "sha256:8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac",
-                "sha256:8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2",
-                "sha256:8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7",
-                "sha256:92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96",
-                "sha256:97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d",
-                "sha256:9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b",
-                "sha256:9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a",
-                "sha256:9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13",
-                "sha256:9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340",
-                "sha256:9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6",
-                "sha256:aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458",
-                "sha256:ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c",
-                "sha256:b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c",
-                "sha256:b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9",
-                "sha256:b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432",
-                "sha256:b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991",
-                "sha256:bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69",
-                "sha256:bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf",
-                "sha256:c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb",
-                "sha256:c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b",
-                "sha256:c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833",
-                "sha256:cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76",
-                "sha256:cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85",
-                "sha256:cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e",
-                "sha256:d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50",
-                "sha256:d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8",
-                "sha256:d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4",
-                "sha256:d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b",
-                "sha256:dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5",
-                "sha256:e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190",
-                "sha256:e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7",
-                "sha256:eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa",
-                "sha256:ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0",
-                "sha256:f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9",
-                "sha256:f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0",
-                "sha256:fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b",
-                "sha256:fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5",
-                "sha256:fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7",
-                "sha256:fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
+                "sha256:00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91",
+                "sha256:01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229",
+                "sha256:056a17eaaf3da87a05523472ae84246f87ac2f29a53306466c22e60282e54ff8",
+                "sha256:0a08c89b23117049ba171bf51d2f9c5f3abf507d65d016d6e0fa2f37e18c0fc5",
+                "sha256:1343df4e2e6e51182aad12162b23b0a4b3fd77f17527a78c53f0f23573663545",
+                "sha256:1449f9451cd53e0fd0a7ec2ff5ede4686add13ac7a7bfa6988ff6d75cff3ebe2",
+                "sha256:16b9ec51cc2feab009e800f2c6327338d6ee4e752c76e95a35c4465e80390ccd",
+                "sha256:1f10f250430a4caf84115b1e0f23f3615566ca2369d1962f82bef40dd99cd81a",
+                "sha256:231142459d32779b209aa4b4d460b175cadd604fed856f25c1571a9d78114771",
+                "sha256:232fd30903d3123be4c435fb5159938c6225ee8607b635a4d3fca847003134ba",
+                "sha256:23d891e5bdc12e2e506e7d225d6aa929e0a0368c9916c1fddefab88166e98b20",
+                "sha256:266f655d1baff9c47b52f529b5f6bec33f66042f65f7c56adde3fcf2ed62ae8b",
+                "sha256:273473d34462ae6e97c0f4e517bd1bf9588aa67a1d47d93f760a1282640e24ac",
+                "sha256:2bd9ac6e44f2db368ef8986f3989a4cad3de4cd55dbdda536e253000c801bcc7",
+                "sha256:33714fcf5af4ff7e70a49731a7cc8fd9ce910b9ac194f66eaa18c3cc0a4c02be",
+                "sha256:359a8b09d712df27849e0bcb62c6a3404e780b274b0b7e4c39a88826d1926c28",
+                "sha256:365005e8b0718ea6d64b374423e870648ab47c3a905356ab6e5a5ff03962b9a9",
+                "sha256:389d2b2e543b27962990ab529ac6720c3dded588cc6d0f6557eec153305a3622",
+                "sha256:3b505f2bbff50d261176e67be24e8909e54b5d9d08b12d4946344066d66b3e43",
+                "sha256:3d74d4a3c4b8f7a1f676cedf8e84bcc57705a6d7925e6daef7a1e54ae543a197",
+                "sha256:3f3f00a9061605725df1816f5713d10cd94636347ed651abdbc75828df302b20",
+                "sha256:43498ea734ccdfb92e1886dfedaebeb81178a241d39a79d5351ba2b671bff2b2",
+                "sha256:4855161013dfb2b762e02b3f4d4a21cc7c6aec13c69e3bffbf5022b3e708dd97",
+                "sha256:4d973729ce04784906a19108054e1fd476bc85279a403ea1a72fdb051c76fa48",
+                "sha256:4ece9cca4cd1c8ba889bfa67eae7f21d0d1a2e715b4d5045395113361e8c533d",
+                "sha256:506becdf2ecaebaf7f7995f776394fcc8bd8a78022772de66677c84fb02dd33d",
+                "sha256:520486f27f1d4ce9654154b4494cf9307b495527f3a2908ad4cb48e4f7ed7ef7",
+                "sha256:5557461f83bb7cc718bc9ee1f7156d50e31747e5b38d79cf40f79ab1447afd2d",
+                "sha256:562778586949be7e0d7435fcb24aca4810913771f845d99145a6cee64d5b67ca",
+                "sha256:59bb5979f9941c61e907ee571732219fa4774d5a18f3fa5ff2df963f5dfaa6bc",
+                "sha256:606d445feeb0856c2b424405236a01c71af7c97e5fe42fbc778634faef2b47e4",
+                "sha256:6197c3f3c0b960ad033b9b7d611db11285bb461fc6b802c1dd50d04ad715c225",
+                "sha256:647459b23594f370c1c01768edaa0ba0959afc39caeeb793b43158bb9bb6a663",
+                "sha256:647bfe88b1997d7ae8d45dabc7c868d8cb0c8412a6e730a7651050b8c7289cf2",
+                "sha256:6bee9c2e501d835f91460b2c904bc359f8433e96799f5c2ff20feebd9bb1e590",
+                "sha256:6dbdacf5752fbd78ccdb434698230c4f0f95df7dd956d5f205b5ed6911a1367c",
+                "sha256:701847a7aaefef121c5c0d855b2affa5f9bd45196ef00266724a80e439220e46",
+                "sha256:786d6b57026e7e04d184313c1359ac3d68002c33e4b1042ca58c362f1d09ff58",
+                "sha256:7b378847a09d6bd46047f5f3599cdc64fcb4cc5a5a2dd0a2af610361fbe77b16",
+                "sha256:7d1d6c9e74c70ddf524e3c09d9dc0522aba9370708c2cb58680ea40174800013",
+                "sha256:857d6565f9aa3464764c2cb6a2e3c2e75e1970e877c188f4aeae45954a314e0c",
+                "sha256:8671622256a0859f5089cbe0ce4693c2af407bc053dcc99aadff7f5310b4aa02",
+                "sha256:88f7c383071981c74ec1998ba9b437659e4fd02a3c4a4d3efc16774eb108d0ec",
+                "sha256:8aecb5a7f6f7f8fe9cac0bcadd39efaca8bbf8d1bf242e9f175cbe4c925116c3",
+                "sha256:91bbf398ac8bb7d65a5a52127407c05f75a18d7015a270fdd94bbcb04e65d573",
+                "sha256:936e8880cc00f839aa4173f94466a8406a96ddce814651075f95837316369899",
+                "sha256:953dd5481bd6252bd480d6ec431f61d7d87fdcbbb71b0d2bdcfc6ae00bb6fb10",
+                "sha256:95ae6c5a196e2f239150aa4a479967351df7f44800c93e5a975ec726fef005e2",
+                "sha256:9a2b5915c333e4364367140443b59f09feae42184459b913f0f41b9fed55794a",
+                "sha256:9ae6c3363261021144121427b1552b29e7b59de9d6a75bf51e03bc072efb3c37",
+                "sha256:9b556596c49fa1232b0fff4b0e69b9d4083a502e60e404b44341e2f8fb7187f5",
+                "sha256:9c131447768ed7bc05a02553d939e7f0e807e533441901dd504e217b76307745",
+                "sha256:9d9d5726474cbbef279fd709008f91a49c4f758bec9c062dfbba88eab00e3ff9",
+                "sha256:a1bdcbebd4e13446a14de4dd1825f1e778e099f17f79718b4aeaf2403624b0f7",
+                "sha256:a602ed9bd2c7d85bd58592c28e101bd9ff9c718fbde06545a70945ffd5d11868",
+                "sha256:a8edae5253efa75c2fc79a90068fe540b197d1c7ab5803b800fccfe240eed33c",
+                "sha256:a905affe76f1802edcac554e3ccf68188bea16546071d7583fb1b693f9cf756b",
+                "sha256:a9e7c6d89c77bb2770c9491d988f26a4b161d05c8ca58f63fb1f1b6b9a74be45",
+                "sha256:aa9b5abd07f71b081a33115d9758ef6077924082055005808f68feccb27616bd",
+                "sha256:aaa5c173a26960fe67daa69aa93d6d6a1cd714a6eb13802d4e4bd1d24a530644",
+                "sha256:ac7674d1638df129d9cb4503d20ffc3922bd463c865ef3cb412f2c926108e9a4",
+                "sha256:b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e",
+                "sha256:b1980dbcaad634fe78e710c8587383e6e3f61dbe146bcbfd13a9c8ab2d7b1192",
+                "sha256:bafa65e3acae612a7799ada439bd202403414ebe23f52e5b17f6ffc2eb98c2be",
+                "sha256:bb5bd6212eb0edfd1e8f254585290ea1dadc3687dd8fd5e2fd9a87c31915cdab",
+                "sha256:bbdd69e20fe2943b51e2841fc1e6a3c1de460d630f65bde12452d8c97209464d",
+                "sha256:bc354b1393dce46026ab13075f77b30e40b61b1a53e852e99d3cc5dd1af4bc85",
+                "sha256:bcee502c649fa6351b44bb014b98c09cb00982a475a1912a9881ca28ab4f9cd9",
+                "sha256:bdd9abccd0927673cffe601d2c6cdad1c9321bf3437a2f507d6b037ef91ea307",
+                "sha256:c42ae7e010d7d6bc51875d768110c10e8a59494855c3d4c348b068f5fb81fdcd",
+                "sha256:c71b5b860c5215fdbaa56f715bc218e45a98477f816b46cfde4a84d25b13274e",
+                "sha256:c7721a3ef41591341388bb2265395ce522aba52f969d33dacd822da8f018aff8",
+                "sha256:ca8e44b5ba3edb682ea4e6185b49661fc22b230cf811b9c13963c9f982d1d964",
+                "sha256:cb53669442895763e61df5c995f0e8361b61662f26c1b04ee82899c2789c8f69",
+                "sha256:cc02c06e9e320869d7d1bd323df6dd4281e78ac2e7f8526835d3d48c69060683",
+                "sha256:d3caa09e613ece43ac292fbed513a4bce170681a447d25ffcbc1b647d45a39c5",
+                "sha256:d82411dbf4d3127b6cde7da0f9373e37ad3a43e89ef374965465928f01c2b979",
+                "sha256:dbcb2dc07308453db428a95a4d03259bd8caea97d7f0776842299f2d00c72fc8",
+                "sha256:dd4fda67f5faaef4f9ee5383435048ee3e11ad996901225ad7615bc92245bc8e",
+                "sha256:ddd92e18b783aeb86ad2132d84a4b795fc5ec612e3545c1b687e7747e66e2b53",
+                "sha256:de362ac8bc962408ad8fae28f3967ce1a262b5d63ab8cefb42662566737f1dc7",
+                "sha256:e214025e23db238805a600f1f37bf9f9a15413c7bf5f9d6ae194f84980c78722",
+                "sha256:e8f9f93a23634cfafbad6e46ad7d09e0f4a25a2400e4a64b1b7b7c0fbaa06d9d",
+                "sha256:e96a1788f24d03e8d61679f9881a883ecdf9c445a38f9ae3f3f193ab6c591c66",
+                "sha256:ec53a09aee61d45e7dbe7e91252ff0491b6b5fee3d85b2d45b173d8ab453efc1",
+                "sha256:f10250bb190fb0742e3e1958dd5c100524c2cc5096c67c8da51233f7448dc137",
+                "sha256:f1faee2a831fe249e1bae9cbc68d3cd8a30f7e37851deee4d7962b17c410dd56",
+                "sha256:f610d980e3fccf4394ab3806de6065682982f3d27c12d4ce3ee46a8183d64a6a",
+                "sha256:f6c35b2f87c004270fa2e703b872fcc984d714d430b305145c39d53074e1ffe0",
+                "sha256:f836f39678cb47c9541f04d8ed4545719dc31ad850bf1832d6b4171e30d65d23",
+                "sha256:f99768232f036b4776ce419d3244a04fe83784bce871b16d2c2e984c7fcea847",
+                "sha256:fd814847901df6e8de13ce69b84c31fc9b3fb591224d6762d0b256d510cbf382",
+                "sha256:fdb325b7fba1e2c40b9b1db407f85642e32404131c08480dd652110fc908561b"
             ],
             "index": "pypi",
-            "version": "==4.9.3"
+            "version": "==4.9.4"
         },
         "pycountry": {
             "hashes": [
@@ -499,40 +500,40 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:970fd9f9f522eb48f3cd5574e927b369279ebf5bcf0f2fae5ed9cc6306e58558",
-                "sha256:aad3f305fe3cd4f2bba545c9580cd460c366af56a8aabb6094528dd32317f8d2"
+                "sha256:111d6ba8e54249c7c163fc18b5fdef0faebdf5ba01be48490527178fd2865a6e",
+                "sha256:e165722c2924decd488bf0cd912dee2296d1d219a55be5dd9c93f2967b57c4e8"
             ],
             "index": "pypi",
-            "version": "==1.34.2"
+            "version": "==1.34.5"
         },
         "boto3-stubs": {
             "extras": [
-                "eventbridge",
+                "events",
                 "s3",
                 "sqs"
             ],
             "hashes": [
-                "sha256:3cdb04dd23ccf64f0b6b4de1f9df70351b248f3332e2e68310555ff8c79f6995",
-                "sha256:e09aafa188c4749db211971a30402f92a57bb0f314772b9f46165376b428c10c"
+                "sha256:223849af19e0b6396b085fdf34598239f37e03bfba105f62902e00c30abe3995",
+                "sha256:49af5906b94d610f79857f6c99b15096750ec0ed13e6d5c10d7ef3bb7cc77a31"
             ],
             "index": "pypi",
-            "version": "==1.34.2"
+            "version": "==1.34.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:655b1ea2a5d7b989a0eb6006c16137f785bc7334f31378115668c4be5d4b00eb",
-                "sha256:8a9f4ad438ba814b9b7a22b24de3004f8aa232e7ae86e0087aea4d7792dc3a2a"
+                "sha256:c339876859bddfc38de9d5409458eaab0ae703da867a3b6474a986bf7db7d967",
+                "sha256:eb2adcde8119f715bc7f6c1a991a962700df1b34bba595056b3be55ffa855e82"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.2"
+            "version": "==1.34.5"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:7e6299577e56c9d4ef899f21e5ebda0ff98beaea524305d02b9b7c16767d9879",
-                "sha256:fb60ca7561b2a9d1ddabdc5eeb96112b2f978ddfa6a294bbe31d2bff5a4e658a"
+                "sha256:66c46b3679e20afb0f5b1a37129d19bf6558ceeac185ea8ad9531f93769adfd8",
+                "sha256:e29dead3fc9d992d772cb7eb1420a929c8f2987a8c7912728f5a8426bbbbddfc"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==1.34.2"
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==1.34.5"
         },
         "certifi": {
             "hashes": [
@@ -844,11 +845,11 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:065e77a12624d05531afa87ade12a0b9bdb53495c4573893252a055b545ce3ea",
-                "sha256:48984397b3b58ef5dfc645d6a304b0060f612bcecfdaaf45ce8aff0077a6cb6a"
+                "sha256:10939b0ba0ff5adaecf3b06a5c2f73071d9678e507c5eaedb23c761d56ac774b",
+                "sha256:55e0fc3c84ebf0a96a5aa23ff8b53d70246479e9a68863f1fcac5a3e52f19dd6"
             ],
             "index": "pypi",
-            "version": "==1.3.1"
+            "version": "==1.4.0"
         },
         "frozenlist": {
             "hashes": [
@@ -1161,36 +1162,43 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:12cce78e329838d70a204293e7b29af9faa3ab14899aec397798a4b41be7f340",
-                "sha256:1484b8fa2c10adf4474f016e09d7a159602f3239075c7bf9f1627f5acf40ad49",
-                "sha256:204e0d6de5fd2317394a4eff62065614c4892d5a4d1a7ee55b765d7a3d9e3f82",
-                "sha256:2643d145af5292ee956aa0a83c2ce1038a3bdb26e033dadeb2f7066fb0c9abce",
-                "sha256:2c6e4464ed5f01dc44dc9821caf67b60a4e5c3b04278286a85c067010653a0eb",
-                "sha256:2f7f6985d05a4e3ce8255396df363046c28bea790e40617654e91ed580ca7c51",
-                "sha256:31902408f4bf54108bbfb2e35369877c01c95adc6192958684473658c322c8a5",
-                "sha256:40716d1f821b89838589e5b3106ebbc23636ffdef5abc31f7cd0266db936067e",
-                "sha256:4b901927f16224d0d143b925ce9a4e6b3a758010673eeded9b748f250cf4e8f7",
-                "sha256:4fc3d14ee80cd22367caaaf6e014494415bf440980a3045bf5045b525680ac33",
-                "sha256:5cf3f0c5ac72139797953bd50bc6c95ac13075e62dbfcc923571180bebb662e9",
-                "sha256:6dbdec441c60699288adf051f51a5d512b0d818526d1dcfff5a41f8cd8b4aaf1",
-                "sha256:72cf32ce7dd3562373f78bd751f73c96cfb441de147cc2448a92c1a308bd0ca6",
-                "sha256:75aa828610b67462ffe3057d4d8a4112105ed211596b750b53cbfe182f44777a",
-                "sha256:75c4d2a6effd015786c87774e04331b6da863fc3fc4e8adfc3b40aa55ab516fe",
-                "sha256:78e25b2fd6cbb55ddfb8058417df193f0129cad5f4ee75d1502248e588d9e0d7",
-                "sha256:84860e06ba363d9c0eeabd45ac0fde4b903ad7aa4f93cd8b648385a888e23200",
-                "sha256:8c5091ebd294f7628eb25ea554852a52058ac81472c921150e3a61cdd68f75a7",
-                "sha256:944bdc21ebd620eafefc090cdf83158393ec2b1391578359776c00de00e8907a",
-                "sha256:9c7ac372232c928fff0645d85f273a726970c014749b924ce5710d7d89763a28",
-                "sha256:d9b338c19fa2412f76e17525c1b4f2c687a55b156320acb588df79f2e6fa9fea",
-                "sha256:ee5d62d28b854eb61889cde4e1dbc10fbaa5560cb39780c3995f6737f7e82120",
-                "sha256:f2c2521a8e4d6d769e3234350ba7b65ff5d527137cdcde13ff4d99114b0c8e7d",
-                "sha256:f6efc9bd72258f89a3816e3a98c09d36f079c223aa345c659622f056b760ab42",
-                "sha256:f7c5d642db47376a0cc130f0de6d055056e010debdaf0707cd2b0fc7e7ef30ea",
-                "sha256:fcb6d9afb1b6208b4c712af0dafdc650f518836065df0d4fb1d800f5d6773db2",
-                "sha256:fcd2572dd4519e8a6642b733cd3a8cfc1ef94bafd0c1ceed9c94fe736cb65b6a"
+                "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6",
+                "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d",
+                "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02",
+                "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d",
+                "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3",
+                "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3",
+                "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3",
+                "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66",
+                "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259",
+                "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835",
+                "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd",
+                "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d",
+                "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8",
+                "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07",
+                "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b",
+                "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e",
+                "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6",
+                "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae",
+                "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9",
+                "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d",
+                "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a",
+                "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592",
+                "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218",
+                "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817",
+                "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4",
+                "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410",
+                "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"
             ],
             "index": "pypi",
-            "version": "==1.7.1"
+            "version": "==1.8.0"
+        },
+        "mypy-boto3-events": {
+            "hashes": [
+                "sha256:0609aaca1d9c34a95e3d8435102a17e3eaa216dc4d97d3041cfe0adca760f57c",
+                "sha256:d674153ac01767ddb3d48996859726f47a6e705601e6390c0bac277d2eb0a316"
+            ],
+            "version": "==1.34.0"
         },
         "mypy-boto3-s3": {
             "hashes": [
@@ -1518,26 +1526,26 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:05ffe9dbd278965271252704eddb97b4384bf58b971054d517decfbf8c523f05",
-                "sha256:5daaeaf00ae3c1efec9742ff294b06c3a2a9db8d3db51ee4851c12ad385cda30",
-                "sha256:7d076717c67b34c162da7c1a5bda16ffc205e0e0072c03745275e7eab888719f",
-                "sha256:7de792582f6e490ae6aef36a58d85df9f7a0cfd1b0d4fe6b4fb51803a3ac96fa",
-                "sha256:a05b0ddd7ea25495e4115a43125e8a7ebed0aa043c3d432de7e7d6e8e8cd6448",
-                "sha256:aa8ee4f8440023b0a6c3707f76cadce8657553655dcbb5fc9b2f9bb9bee389f6",
-                "sha256:b6a21ab023124eafb7cef6d038f835cb1155cd5ea798edd8d9eb2f8b84be07d9",
-                "sha256:bd8ee69b02e7bdefe1e5da2d5b6eaaddcf4f90859f00281b2333c0e3a0cc9cd6",
-                "sha256:c8e3255afd186c142eef4ec400d7826134f028a85da2146102a1172ecc7c3696",
-                "sha256:ce697c463458555027dfb194cb96d26608abab920fa85213deb5edf26e026664",
-                "sha256:db6cedd9ffed55548ab313ad718bc34582d394e27a7875b4b952c2d29c001b26",
-                "sha256:e49fbdfe257fa41e5c9e13c79b9e79a23a79bd0e40b9314bc53840f520c2c0b3",
-                "sha256:e6f08ca730f4dc1b76b473bdf30b1b37d42da379202a059eae54ec7fc1fbcfed",
-                "sha256:f35960b02df6b827c1b903091bb14f4b003f6cf102705efc4ce78132a0aa5af3",
-                "sha256:f41f692f1691ad87f51708b823af4bb2c5c87c9248ddd3191c8f088e66ce590a",
-                "sha256:f7ee467677467526cfe135eab86a40a0e8db43117936ac4f9b469ce9cdb3fb62",
-                "sha256:ff78a7583020da124dd0deb835ece1d87bb91762d40c514ee9b67a087940528b"
+                "sha256:0e17f53bcbb4fff8292dfd84cf72d767b5e146f009cccd40c2fad27641f8a7a9",
+                "sha256:104aa9b5e12cb755d9dce698ab1b97726b83012487af415a4512fedd38b1459e",
+                "sha256:1e63bf5a4a91971082a4768a0aba9383c12392d0d6f1e2be2248c1f9054a20da",
+                "sha256:28d920e319783d5303333630dae46ecc80b7ba294aeffedf946a02ac0b7cc3db",
+                "sha256:2aec598fb65084e41a9c5d4b95726173768a62055aafb07b4eff976bac72a592",
+                "sha256:331aae2cd4a0554667ac683243b151c74bd60e78fb08c3c2a4ac05ee1e606a39",
+                "sha256:479ca4250cab30f9218b2e563adc362bd6ae6343df7c7b5a7865300a5156d5a6",
+                "sha256:4d0738917c203246f3e275b37006faa3aa96c828b284ebfe3e99a8cb413c8c4b",
+                "sha256:69dac82d63a50df2ab0906d97a01549f814b16bc806deeac4f064ff95c47ddf5",
+                "sha256:744dfe4b35470fa3820d5fe45758aace6269c578f7ddc43d447868cfe5078bcb",
+                "sha256:8151425a60878e66f23ad47da39265fc2fad42aed06fb0a01130e967a7a064f4",
+                "sha256:837c739729394df98f342319f5136f33c65286b28b6b70a87c28f59354ec939b",
+                "sha256:aa8344310f1ae79af9ccd6e4b32749e93cddc078f9b5ccd0e45bd76a6d2e8bb6",
+                "sha256:b041dee2734719ddbb4518f762c982f2e912e7f28b8ee4fe1dee0b15d1b6e800",
+                "sha256:c497d769164df522fdaf54c6eba93f397342fe4ca2123a2e014a5b8fc7df81c7",
+                "sha256:e6837202c2859b9f22e43cb01992373c2dbfeae5c0c91ad691a4a2e725392464",
+                "sha256:e6a212f436122ac73df851f0cf006e0c6612fe6f9c864ed17ebefce0eff6a5fd"
             ],
             "index": "pypi",
-            "version": "==0.1.8"
+            "version": "==0.1.9"
         },
         "s3transfer": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ S3_PUBLIC_CDN_ROOT=### S3 bucket + prefix for CDN public, e.g. 's3://<bucket>/pa
 
 ### Optional
 ```shell
-GEOHARVESTER_SQS_TOPIC_NAME=### default value for CLI argument --sqs-arn
+GEOHARVESTER_SQS_TOPIC_NAME=### default value for CLI argument --sqs-topic-name
 ```
 
 ## CLI Commands

--- a/harvester/aws/eventbridge.py
+++ b/harvester/aws/eventbridge.py
@@ -1,1 +1,39 @@
 """harvester.aws.eventbridge"""
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import boto3
+
+if TYPE_CHECKING:
+    from mypy_boto3_events.client import (  # noqa: I001
+        EventBridgeClient as EventBridgeClientType,
+    )  # pragma: nocover
+
+
+logger = logging.getLogger(__name__)
+
+
+class EventBridgeClient:
+    @classmethod
+    def get_client(cls) -> "EventBridgeClientType":
+        return boto3.client("events")
+
+    @classmethod
+    def send_event(cls, detail: dict) -> str:
+        """Send EventBridge event."""
+        response = cls.get_client().put_events(
+            Entries=[
+                {
+                    "Detail": json.dumps(detail),
+                    "DetailType": "geo-harvester run",
+                    "Source": "geo-harvester.app",
+                    "EventBusName": "default",
+                },
+            ]
+        )
+        created_event_id = response["Entries"][0]["EventId"]
+        message = f"EventBridge event created: {created_event_id}"
+        logger.debug(message)
+        return created_event_id

--- a/harvester/harvest/mit.py
+++ b/harvester/harvest/mit.py
@@ -109,7 +109,7 @@ class MITHarvester(Harvester):
                 - detail.restricted=false
             2. Delete zip file data from Public CDN bucket
                 - detail.restricted=true
-            3. Delete zip file data AND metadata from Public CDN bucket
+            3. Delete zip file data AND metadata from Public AND Restricted CDN bucket
                 - detail.deleted=true
 
         The goal is to decouple KNOWING whether a record is deleted or restricted (this

--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -65,7 +65,7 @@ class FGDC(XMLSourceRecord):
         value_map = {
             "vector digital data": "Datasets",
             "raster digital data": "Datasets",
-            "remote-sensing image": "Image",
+            "remote-sensing image": "Imagery",
         }
         xpath_expr = """
         //idinfo

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -291,6 +291,16 @@ class SourceRecord:
             None: True,
         }[self._dct_accessRights_s()]
 
+    @property
+    def is_deleted(self) -> bool:
+        """Property to return boolean if source record is considered deleted.
+
+        This valuation is based on the event that brought the record into harvest.
+        """
+        if self.event == "deleted":
+            return True
+        return False
+
     def normalize(self) -> MITAardvark:
         """Method to normalize a SourceRecord to an MIT Aardvark MITAardvark instance.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,3 +396,14 @@ def mocked_normalized_writer(generic_harvester_class):
     mock_normalized_writer = MagicMock()
     generic_harvester_class._write_normalized_metadata = mock_normalized_writer
     return mock_normalized_writer
+
+
+@pytest.fixture
+def records_for_mit_steps(records_for_writing):
+    return records_for_writing
+
+
+@pytest.fixture
+def mock_eventbridge_client(mock_boto3_sqs_client):
+    with patch("harvester.aws.eventbridge.boto3.client") as mock_client:
+        yield mock_client.return_value

--- a/tests/test_aws/test_eventbridge.py
+++ b/tests/test_aws/test_eventbridge.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from harvester.aws.eventbridge import EventBridgeClient
+
+
+def test_eventbridge_client_get_client_success(mock_eventbridge_client):
+    assert EventBridgeClient.get_client() == mock_eventbridge_client
+
+
+def test_eventbridge_client_put_events_success(mock_eventbridge_client):
+    payload = {"msg": "in a bottle"}
+    with patch.object(mock_eventbridge_client, "put_events") as mocked_put:
+        EventBridgeClient.send_event(detail=payload)
+    mocked_put.assert_called_with(
+        Entries=[
+            {
+                "Detail": '{"msg": "in a bottle"}',  # JSON serialized
+                "DetailType": "geo-harvester run",  # default values
+                "Source": "geo-harvester.app",
+                "EventBusName": "default",
+            }
+        ]
+    )

--- a/tests/test_harvest/test_mit_harvester.py
+++ b/tests/test_harvest/test_mit_harvester.py
@@ -1,4 +1,4 @@
-# ruff: noqa: SLF001, D212, D200
+# ruff: noqa: SLF001, D212, D200, ARG002, TRY002, TRY003, EM101
 from unittest import mock
 
 import pytest
@@ -182,7 +182,7 @@ def test_mit_harvester_find_metadata_file_missing_file_error():
 
 def test_mit_harvester_metadata_file_use_skip_list_success():
     """
-    NOTE: tis zip file contains EG_CAIRO_A25TOPO_1972.aux.xml which should be skipped
+    NOTE: this zip file contains EG_CAIRO_A25TOPO_1972.aux.xml which should be skipped
     """
     source_record = MITHarvester.create_source_record_from_zip_file(
         identifier="EG_CAIRO_A25TOPO_1972",
@@ -194,3 +194,120 @@ def test_mit_harvester_metadata_file_use_skip_list_success():
         source_record.zip_file_location
         == "tests/fixtures/zip_files/EG_CAIRO_A25TOPO_1972.zip"
     )
+
+
+def test_mit_harvester_harvester_specific_steps_success(records_for_mit_steps):
+    class MockMITHarvester(MITHarvester):
+        def send_eventbridge_event(self, records):
+            yield from records
+
+        def delete_sqs_messages(self, records):
+            yield from records
+
+    harvester = MockMITHarvester(
+        harvest_type="incremental",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+    )
+    output_records = list(harvester.harvester_specific_steps(records_for_mit_steps))
+    assert output_records == records_for_mit_steps
+
+
+def test_mit_harvester_send_eventbridge_event_success(caplog, records_for_mit_steps):
+    caplog.set_level("DEBUG")
+
+    class MockMITHarvester(MITHarvester):
+        def _prepare_payload_and_send_event(self, bucket, path, record):
+            return "uuid-abc123-def456"
+
+    harvester = MockMITHarvester(
+        harvest_type="full",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+    )
+    output_record = next(harvester.send_eventbridge_event(records_for_mit_steps))
+    assert "sending EventBridge event" in caplog.text
+    assert output_record.exception is None
+
+
+def test_mit_harvester_send_eventbridge_event_error_log_and_yield(
+    caplog, records_for_mit_steps
+):
+    caplog.set_level("DEBUG")
+
+    class MockMITHarvester(MITHarvester):
+        def _prepare_payload_and_send_event(self, bucket, path, record):
+            raise Exception("Error sending event")
+
+    harvester = MockMITHarvester(
+        harvest_type="full",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+    )
+    output_record = next(harvester.send_eventbridge_event(records_for_mit_steps))
+    assert "sending EventBridge event" in caplog.text
+    assert str(output_record.exception) == "Error sending event"
+    assert output_record.exception_stage == "send_eventbridge_event"
+
+
+def test_mit_harvester_prepare_payload_and_send_event_success(records_for_mit_steps):
+    record = records_for_mit_steps[0]
+    harvester = MITHarvester(
+        harvest_type="full",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+    )
+    with mock.patch(
+        "harvester.harvest.mit.EventBridgeClient.send_event"
+    ) as mocked_send_event:
+        harvester._prepare_payload_and_send_event(
+            "the-bucket",
+            "/path/here",
+            record,
+        )
+        mocked_send_event.assert_called_with(
+            detail={
+                "bucket": "the-bucket",
+                "identifier": "SDE_DATA_AE_A8GNS_2003",
+                "restricted": "false",
+                "deleted": "false",
+                "objects": [
+                    {"Key": "/path/here/SDE_DATA_AE_A8GNS_2003.source.fgdc.xml"},
+                    {"Key": "/path/here/SDE_DATA_AE_A8GNS_2003.normalized.aardvark.json"},
+                    {"Key": "/path/here/SDE_DATA_AE_A8GNS_2003.zip"},
+                ],
+            }
+        )
+
+
+def test_mit_harvester_delete_sqs_messages_preserve_flag_skip_step(
+    caplog, records_for_mit_steps
+):
+    harvester = MITHarvester(
+        harvest_type="full",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+        preserve_sqs_messages=True,
+    )
+    _output_records = list(harvester.delete_sqs_messages(records_for_mit_steps))
+    assert "Flag preserve_sqs_messages set, skipping delete of SQS message" in caplog.text
+
+
+def test_mit_harvester_delete_sqs_messages_success(
+    caplog, records_for_mit_steps, valid_sqs_message_created_instance, mock_sqs_client
+):
+    caplog.set_level("DEBUG")
+    records_for_mit_steps[
+        0
+    ].source_record.sqs_message = valid_sqs_message_created_instance
+    harvester = MITHarvester(
+        harvest_type="incremental",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+    )
+    with mock.patch.object(harvester.sqs_client, "delete_message") as mocked_delete:
+        _output_records = list(harvester.delete_sqs_messages(records_for_mit_steps))
+        assert "Record SDE_DATA_AE_A8GNS_2003: deleting SQS message" in caplog.text
+        mocked_delete.assert_called_with(
+            valid_sqs_message_created_instance.receipt_handle
+        )

--- a/tests/test_records/test_fgdc.py
+++ b/tests/test_records/test_fgdc.py
@@ -42,7 +42,7 @@ def test_fgdc_record_required_dct_title_s_missing_raises_error(
 
 
 def test_fgdc_record_required_gbl_resourceClass_sm(fgdc_source_record_required_fields):
-    assert fgdc_source_record_required_fields._gbl_resourceClass_sm() == ["Image"]
+    assert fgdc_source_record_required_fields._gbl_resourceClass_sm() == ["Imagery"]
 
 
 def test_fgdc_record_required_gbl_resourceClass_sm_missing_return_empty_list(


### PR DESCRIPTION
### Purpose and background context
This PR allows the GeoHarvester to send EventBridge (EB) events when processing MIT harvests.  

From the `send_eventbridge_events()` method:
```
These events are handled by the StepFunction "geo-upload-<ENV>-shapefile-handler".
That StepFunction will take one of three paths based on the event payload:

    1. Copy zip file data from Restricted to Public CDN bucket
        - detail.restricted=false
    2. Delete zip file data from Public CDN bucket
        - detail.restricted=true
    3. Delete zip file data AND metadata from Public CDN bucket
        - detail.deleted=true

The goal is to decouple KNOWING whether a record is deleted or restricted (this
harvester) and actually MANAGING files in S3.  By sending EventBridge events about
the record's deleted and restricted status, that work is handled elsewhere.
```

**NOTE**: It is possible that OGM may harvests may also need to send EventBridge events, e.g. we determine that an OGM resource is deleted, then sending an EB event is the mechanism by which the metadata is deleted from the Public CDN bucket.  However, OGM harvests have been deprioritized until MIT harvests are fully formed, and so I'd propose to keep this logic as an MIT "harvester specific step" until the OGM work is started.  Perhaps they will duplicate some logic, perhaps it will be refactored as a shared step.

### How can a reviewer manually see the effects of these changes?

1- Set env vars:
```shell
WORKSPACE=dev
SENTRY_DSN=None
S3_RESTRICTED_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/restricted/
S3_PUBLIC_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/public/
GEOHARVESTER_SQS_TOPIC_NAME=geo-harvester-input-dev
```

2- Ensure AWS credentials are set for `TimdexManagers` in Dev1

3- Note the contents of [Public CDN S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/cdn-origin-dev-222053980223?region=us-east-1&prefix=cdn/geo/public/&showversions=false).  Easiest way is likely to note timestamps of files, so you can observe they were updated.

4- Run local harvest of 4 sample zip files in fixtures:
```shell
pipenv run harvester --verbose harvest \
--harvest-type="full" \
--output-file="s3://timdex-extract-dev-222053980223/geo/my-unique-filename-here.jsonl" \
mit \
--input-files="tests/fixtures/zip_files" \
--skip-sqs-check
```

After the harvest, note the following:
- Debug output logs should show events are created:

> `2023-12-22 10:26:40,846 DEBUG harvester.aws.eventbridge.send_event() line 38: EventBridge event created: d17ca36c-737e-e8d0-0f4f-1ce18d8c1208`

-  Note that a the zip file `SDE_DATA_AE_A8GNS_2003.zip` was created or modified in the [Public CDN bucket](https://s3.console.aws.amazon.com/s3/buckets/cdn-origin-dev-222053980223?region=us-east-1&prefix=cdn/geo/public/&showversions=false); this is a result of the StepFunction handling the EventBridge event and copying the zip file from the Restricted CDN to Public CDN because the normalization of metadata indicated it is NOT a restricted resource

- Observe the executions for the [associated StepFunction](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn:aws:states:us-east-1:222053980223:stateMachine:geo-upload-dev-shapefile-handler); it should have 4 new invocations from the 4 records processed, each sending an EventBridge event
  - for bonus points, observe those invocations and note that some of them result in the step `DeleteDataFromPublic`, as those resources were Restricted, therefore we need to _remove_ from the Public bucket (gracefully handling if the file was not Public previously, so more like an attempt)

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES - StepFunction may be invoked from MIT harvests

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-87

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes

