### PR TITLE
Fix order of coordinates in WKT string

### DIFF
--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -111,9 +111,9 @@ class FGDC(XMLSourceRecord):
         lat_lon_envelope = ", ".join(
             [
                 min(bbox_data["westbc"]).strip(),
-                max(bbox_data["southbc"]).strip(),
                 max(bbox_data["eastbc"]).strip(),
                 min(bbox_data["northbc"]).strip(),
+                max(bbox_data["southbc"]).strip(),
             ]
         )
         return f"ENVELOPE({lat_lon_envelope})"

--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -112,8 +112,8 @@ class FGDC(XMLSourceRecord):
             [
                 min(bbox_data["westbc"]).strip(),
                 max(bbox_data["eastbc"]).strip(),
-                min(bbox_data["northbc"]).strip(),
-                max(bbox_data["southbc"]).strip(),
+                max(bbox_data["northbc"]).strip(),
+                min(bbox_data["southbc"]).strip(),
             ]
         )
         return f"ENVELOPE({lat_lon_envelope})"

--- a/harvester/records/iso19139.py
+++ b/harvester/records/iso19139.py
@@ -179,8 +179,8 @@ class ISO19139(XMLSourceRecord):
             [
                 min(bbox_data["westBoundLongitude"]).strip(),
                 max(bbox_data["eastBoundLongitude"]).strip(),
-                min(bbox_data["northBoundLatitude"]).strip(),
-                max(bbox_data["southBoundLatitude"]).strip(),
+                max(bbox_data["northBoundLatitude"]).strip(),
+                min(bbox_data["southBoundLatitude"]).strip(),
             ]
         )
 

--- a/harvester/records/iso19139.py
+++ b/harvester/records/iso19139.py
@@ -178,9 +178,9 @@ class ISO19139(XMLSourceRecord):
         lat_lon_envelope = ", ".join(
             [
                 min(bbox_data["westBoundLongitude"]).strip(),
-                max(bbox_data["southBoundLatitude"]).strip(),
                 max(bbox_data["eastBoundLongitude"]).strip(),
                 min(bbox_data["northBoundLatitude"]).strip(),
+                max(bbox_data["southBoundLatitude"]).strip(),
             ]
         )
 

--- a/tests/test_records/test_fgdc.py
+++ b/tests/test_records/test_fgdc.py
@@ -60,14 +60,14 @@ def test_fgdc_record_required_gbl_resourceClass_sm_unhandled_value_return_none(
 def test_fgdc_record_required_dcat_bbox(fgdc_source_record_required_fields):
     assert (
         fgdc_source_record_required_fields._dcat_bbox()
-        == "ENVELOPE(31.161907, 29.994131, 31.381609, 30.141311)"
+        == "ENVELOPE(31.161907, 31.381609, 30.141311, 29.994131)"
     )
 
 
 def test_fgdc_record_required_locn_geometry(fgdc_source_record_required_fields):
     assert (
         fgdc_source_record_required_fields._locn_geometry()
-        == "ENVELOPE(31.161907, 29.994131, 31.381609, 30.141311)"
+        == "ENVELOPE(31.161907, 31.381609, 30.141311, 29.994131)"
     )
 
 

--- a/tests/test_records/test_iso19139.py
+++ b/tests/test_records/test_iso19139.py
@@ -65,14 +65,14 @@ def test_iso19139_record_required_gbl_resourceClass_sm_unhandled_value_return_no
 def test_iso19139_record_required_dcat_bbox(iso19139_source_record_required_fields):
     assert (
         iso19139_source_record_required_fields._dcat_bbox()
-        == "ENVELOPE(88, -16.5, 138, 25.833333)"
+        == "ENVELOPE(88, 138, 25.833333, -16.5)"
     )
 
 
 def test_iso19139_record_required_locn_geometry(iso19139_source_record_required_fields):
     assert (
         iso19139_source_record_required_fields._locn_geometry()
-        == "ENVELOPE(88, -16.5, 138, 25.833333)"
+        == "ENVELOPE(88, 138, 25.833333, -16.5)"
     )
 
 


### PR DESCRIPTION
### Purpose and background context
This PR fixes the order of coordinates for WKT strings in `dcat_bbox` and `locn_geometry` MITAardvark output records.

WKT (Well Known Strings) bounding boxes should be in the form of West/East/North/South, more explicitly `ENVELOPE(MIN Western Longitude, MAX Eastern Longitude, MAX North Latitude, MIN South Latitude)`.  Previously, we had West/South/North/East.

### How can a reviewer manually see the effects of these changes?
The change is pretty minimal, just reordering coordinates which the code and test changes indicate.

It's difficult to test easily at this time, but I have confirmed that by reordering the coordinates, then indexing into a local OpenSearch instance, the records are now findable via a query like this which looks for a single point that falls inside a `locations.geoshape` WKT string:

```json
{
  "query": {
    "bool" : {
      "must" : {
        "match_all" : {}
      },
      "filter" : {
        "geo_shape" : {
          "locations.geoshape": {
            "shape": {
              "type": "point",
              "coordinates": [-71, 42]
            },
            "relation": "contains"
          }
        }
      }
    }
  }
}
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-116

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

