### PR TITLE
Gdt 149 updates from full mit harvest

### DIFF
--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -10,7 +10,7 @@ from dateutil.parser import ParserError
 from lxml import etree
 
 from harvester.records.record import XMLSourceRecord
-from harvester.utils import convert_lang_code, date_parser
+from harvester.utils import convert_lang_code, date_parser, dedupe_list_of_values
 
 logger = logging.getLogger(__name__)
 
@@ -129,8 +129,12 @@ class FGDC(XMLSourceRecord):
     # Optional Field Methods
     ##########################
     def _dct_identifier_sm(self) -> list[str]:
-        # <sdtsterm> identifiers
         identifiers = []
+
+        # include TIMDEX pipeline identifier
+        identifiers.append(self.identifier)
+
+        # <sdtsterm> identifiers
         xpath_expr = """
         //spdoinfo
             /ptvctinf
@@ -160,7 +164,7 @@ class FGDC(XMLSourceRecord):
         """
         identifiers.extend(self.string_list_from_xpath(xpath_expr))
 
-        return identifiers
+        return dedupe_list_of_values(identifiers)
 
     def _dct_subject_sm(self) -> list[str]:
         xpath_expr = """

--- a/tests/test_records/test_fgdc.py
+++ b/tests/test_records/test_fgdc.py
@@ -78,6 +78,7 @@ def test_fgdc_record_required_locn_geometry(fgdc_source_record_required_fields):
 
 def test_fgdc_optional_dct_identifier_sm(fgdc_source_record_all_fields):
     assert fgdc_source_record_all_fields._dct_identifier_sm() == [
+        "SDE_DATA_US_P2HIGHWAYS_2005",
         "BKMapPLUTO",
         "US_NY_NYC_BK_G47TXLOTS_2012",
     ]

--- a/tests/test_records/test_record.py
+++ b/tests/test_records/test_record.py
@@ -158,26 +158,30 @@ def test_record_shared_field_method_dct_references_s_success(
     fgdc_source_record_from_zip,
 ):
     references = {
-        "https://schema.org/downloadUrl": [
+        "http://schema.org/downloadUrl": [
             {
                 "label": "Source Metadata",
-                "protocol": "Download",
                 "url": "https://cdn.dev1.mitlibrary.net/geo/public"
                 "/SDE_DATA_AE_A8GNS_2003.source.fgdc.xml",
             },
             {
-                "label": "Normalized Metadata",
-                "protocol": "Download",
+                "label": "Aardvark Metadata",
                 "url": "https://cdn.dev1.mitlibrary.net/geo/public"
                 "/SDE_DATA_AE_A8GNS_2003.normalized.aardvark.json",
             },
             {
-                "label": "Data Zipfile",
-                "protocol": "Download",
+                "label": "Data",
                 "url": "https://cdn.dev1.mitlibrary.net/geo/public"
                 "/SDE_DATA_AE_A8GNS_2003.zip",
             },
-        ]
+        ],
+        "http://schema.org/url": [
+            {
+                "label": "Website",
+                "url": "https://search.libraries.mit.edu/record/"
+                "gismit:SDE_DATA_AE_A8GNS_2003",
+            },
+        ],
     }
     assert fgdc_source_record_from_zip._dct_references_s() == json.dumps(references)
 


### PR DESCRIPTION
### Purpose and background context
Small updates to GeoHarvester metadata normalization to MIT Aardvark:
  * always add TIMDEX identifier to `dct_identifiers_sm` array ([commit](https://github.com/MITLibraries/geo-harvester/commit/67fa26b87523136c9671b1eb7dc28904dd41cf31))
  * update `dct_references_s` JSON string to include website URL link and update structure of download links ([commit](https://github.com/MITLibraries/geo-harvester/commit/b89f01e1a470b2b3b317f3a02670fb18e0bea654))

### How can a reviewer manually see the effects of these changes?
With the churn of files in Dev1, a bit difficult to easily see these updates, but the modified tests should fairly clearly show the modified output.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Transmogrifier will have a related PR that handles the new `dct_references_s` value

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-149

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

