### PR TITLE
Adjustment for memory constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Options:
                              empty for 'full' harvest.
   --preserve-sqs-messages    If set, SQS messages will remain in the queue
                              after incremental harvest.
+  --skip-eventbridge-events  If set, will skip sending EventBridge events to
+                             manage files in CDN.
   -h, --help                 Show this message and exit.
 ```
 

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -159,6 +159,12 @@ main.add_command(harvest)
     is_flag=True,
     help="If set, SQS messages will remain in the queue after incremental harvest.",
 )
+@click.option(
+    "--skip-eventbridge-events",
+    required=False,
+    is_flag=True,
+    help="If set, will skip sending EventBridge events to manage files in CDN.",
+)
 @click.pass_context
 def harvest_mit(
     ctx: click.Context,
@@ -166,6 +172,7 @@ def harvest_mit(
     sqs_topic_name: str,
     skip_sqs_check: bool,
     preserve_sqs_messages: bool,
+    skip_eventbridge_events: bool,
 ) -> None:
     """Harvest and normalize MIT geospatial metadata records."""
     harvester = MITHarvester(
@@ -176,6 +183,7 @@ def harvest_mit(
         sqs_topic_name=sqs_topic_name,
         skip_sqs_check=skip_sqs_check,
         preserve_sqs_messages=preserve_sqs_messages,
+        skip_eventbridge_events=skip_eventbridge_events,
         output_source_directory=ctx.obj["OUTPUT_SOURCE_DIRECTORY"],
         output_normalized_directory=ctx.obj["OUTPUT_NORMALIZED_DIRECTORY"],
         output_file=ctx.obj["OUTPUT_FILE"],

--- a/tests/test_harvest/test_harvester.py
+++ b/tests/test_harvest/test_harvester.py
@@ -101,6 +101,10 @@ def test_harvester_records_with_error_filtered_out(generic_harvester_class):
     harvester = generic_harvester_class(harvest_type="full")
     assert len(list(harvester.filter_failed_records(records))) == 1
     assert len(harvester.failed_records) == 1
+    failed_record = harvester.failed_records[0]
+    assert failed_record["record_identifier"] == "abc123"
+    assert failed_record["harvest_step"] == "get_source_records"
+    assert str(failed_record["exception"]) == "I have an error"
 
 
 def test_harvester_step_get_source_records(caplog, generic_harvester_class):

--- a/tests/test_harvest/test_mit_harvester.py
+++ b/tests/test_harvest/test_mit_harvester.py
@@ -311,3 +311,17 @@ def test_mit_harvester_delete_sqs_messages_success(
         mocked_delete.assert_called_with(
             valid_sqs_message_created_instance.receipt_handle
         )
+
+
+def test_mit_harvester_skip_send_eventbridge_event(caplog, records_for_mit_steps):
+    harvester = MITHarvester(
+        harvest_type="full",
+        input_files="tests/fixtures/s3_cdn_restricted_legacy_single",
+        skip_sqs_check=True,
+        skip_eventbridge_events=True,
+    )
+    with mock.patch(
+        "harvester.harvest.mit.MITHarvester._prepare_payload_and_send_event"
+    ) as mocked_send_event:
+        _results = list(harvester.send_eventbridge_event(records_for_mit_steps))
+        mocked_send_event.assert_not_called()


### PR DESCRIPTION
### Purpose and background context
A [recent full harvest of the GeoHarvester via the TIMDEX StepFunction](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:7ad5528c-eabb-40cc-9d89-f53a882ace99) failed because the ECS container ran out of memory.  This was anticipated but not confirmed until now.  

This was a result of the `Harvester` maintaining the successful and failed `Record` objects on the harvester instance throughout the harvest.  With a `Record` object containing both the source XML and normalized JSON (at least for MIT harvests), the volume of data becomes substantial over time; at least for a 512mb container.

The following is a screenshot of ECS container metrics from the failed run.  Note the linearly increasing memory that eventually runs out:

<img width="970" alt="Screenshot 2024-01-26 at 1 05 56 PM" src="https://github.com/MITLibraries/geo-harvester/assets/1753087/5a82929b-33e5-4f26-9503-48aafad69fe1">

This PR updates the harvester in two important ways:
  * for records successfully processed, only the identifier is saved on the harvester ([commit](https://github.com/MITLibraries/geo-harvester/commit/e96ce11fb4289ae4a2b61249fcb9d8ee3651f76c))
  * for failed records, only the record's identifier, failed harvest step name, and `Exception` object are saved on the harvester ([commit](https://github.com/MITLibraries/geo-harvester/commit/37639b6cbdb5672ed4e824e77dcfe054759eef59))

The following is the same ECS container metrics, but now the memory nearly flatlines once in the main iteration loop:

<img width="1499" alt="Screenshot 2024-01-26 at 6 35 35 PM" src="https://github.com/MITLibraries/geo-harvester/assets/1753087/2a3b52aa-a106-48c1-9db9-f44374899951">

This screenshot was taken before the failed records adjustment, so the memory consumption may grow even slower.

Taken altogether, this should be sufficient for very large harvests (e.g. OGM with 120k+ records).  

### How can a reviewer manually see the effects of these changes?

Set env vars:
```shell
WORKSPACE=dev
SENTRY_DSN=None
S3_RESTRICTED_CDN_ROOT=/tmp
S3_PUBLIC_CDN_ROOT=/tmp
GEOHARVESTER_SQS_TOPIC_NAME=geo-harvester-input-dev
AWS_ACCESS_KEY_ID=<KEY HERE UNQUOTED>
AWS_SECRET_ACCESS_KEY=<SECRET HERE UNQUOTED>
AWS_SESSION_TOKEN=<SESSION TOKEN UNQUOTED>
```

Run full harvest against Dev1 files, but ALL outputs of the harvester will be internal to the local docker container:
```shell
docker run --env-file .env \
geo-harvester-dev:latest --verbose harvest \
--harvest-type="full" \
--output-file="/tmp/output.jsonl" \
mit \
--input-files="s3://cdn-origin-dev-222053980223/cdn/geo/restricted/" \
--skip-sqs-check \
--skip-eventbridge-events
```

While this runs -- and it should take some time as there are 2k+ zip files here -- monitor docker stats with the following command in another terminal window:
```
docker stats
```

Here is a screenshot showing memory for this container (and a couple of others that were running) on my machine:

<img width="990" alt="Screenshot 2024-01-29 at 10 59 19 AM" src="https://github.com/MITLibraries/geo-harvester/assets/1753087/7703c344-e5cd-4de8-a89b-08d9b3edb2ae">

Note that the memory consumption of the container remains fairly stable.  It will still grow slowly, but orders of magnitude slower than before as successful and failed records are no longer fully maintained in memory as items on the `Harvester` instance.

`Ctrl + C` will stop the docker container anytime satisfied memory is not growing rapidly and stop the harvest and container, which will naturally remove files saved locally inside the container.

### Discussion

This harvester is almost entirely IO bound, with lots of read network calls to S3 to read zip files and write network calls to S3 writing source + normalized metadata, and appending to a growing JSONLines file.

One dramatic performance improvement could be writing all metadata files locally inside the container, and either writing them all at once to S3 at the end of harvest, or performing batch writes along the way (e.g. every 100 records).  

But this introduces some complexity that may not be worth the performance gain.  In most cases, the "daily" harvests will be very, very small.  The readability and linear logic of the current implementation is easily efficient enough.  Similarly, for OGM harvests there are far fewer network writes.  

Lastly, the OGM work may further stress test the current implementation.  If batch writing seems appealing then, as we'll be writing potentially 100k+ files to JSONlines, it might be the time to make this change.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-156

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes

