### PR TITLE
Add OGM harvest to CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,15 @@ Options:
 
 ### `harvester harvest ogm`
 
-_Work in progress, OGM harvests not yet supported from CLI..._
+```text
+Usage: -c harvest ogm [OPTIONS]
+
+  Harvest and normalize OpenGeoMetadata (OGM) geospatial metadata records.
+
+Options:
+  --include-repositories TEXT  If set, limit to only these comma seperated
+                               list of repositories for harvest.
+  --exclude-repositories TEXT  If set, exclude these comma seperated list of
+                               repositories from harvest.
+  -h, --help                   Show this message and exit.
+```

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ Usage: -c harvest ogm [OPTIONS]
   Harvest and normalize OpenGeoMetadata (OGM) geospatial metadata records.
 
 Options:
-  --include-repositories TEXT  If set, limit to only these comma seperated
+  --include-repositories TEXT  If set, limit to only this comma seperated
                                list of repositories for harvest.
-  --exclude-repositories TEXT  If set, exclude these comma seperated list of
+  --exclude-repositories TEXT  If set, exclude this comma seperated list of
                                repositories from harvest.
   -h, --help                   Show this message and exit.
 ```

--- a/harvester/config.py
+++ b/harvester/config.py
@@ -16,7 +16,9 @@ class Config:
     )
     OPTIONAL_ENV_VARS = (
         "GEOHARVESTER_SQS_TOPIC_NAME",
+        "OGM_CONFIG_FILEPATH",
         "OGM_CLONE_ROOT_URL",
+        "OGM_CLONE_ROOT_DIR",
         "GITHUB_API_TOKEN",
     )
 

--- a/harvester/harvest/ogm.py
+++ b/harvester/harvest/ogm.py
@@ -220,7 +220,8 @@ class OGMRepository:
         """
         message = f"Removing local clone: {self.local_repository_directory}"
         logger.debug(message)
-        shutil.rmtree(self.local_repository_directory)
+        if os.path.exists(self.local_repository_directory):
+            shutil.rmtree(self.local_repository_directory)
 
     def get_all_records(self) -> Iterator["OGMRecord"]:
         """Get all records from current state of the repository."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,3 +658,9 @@ def init_ogm_git_project_repos(
         make_commit(repo, "Removed second file and add third", 2020)
 
         yield None
+
+
+@pytest.fixture
+def mocked_ogm_harvester():
+    with patch("harvester.cli.OGMHarvester") as mock_harvester:
+        yield mock_harvester

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_harvest_mit_full_legacy_single_success(
     assert result.exit_code == 0
 
 
-def test_cli_harvest_ogm_no_options_okay_success(runner, mocked_ogm_harvester):
+def test_cli_harvest_ogm_no_options_success(runner, mocked_ogm_harvester):
     result = runner.invoke(
         main, ["--verbose", "harvest", "ogm"], obj={"START_TIME": perf_counter()}
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,3 +66,40 @@ def test_cli_harvest_mit_full_legacy_single_success(
         obj={"START_TIME": perf_counter()},
     )
     assert result.exit_code == 0
+
+
+def test_cli_harvest_ogm_no_options_okay_success(runner, mocked_ogm_harvester):
+    result = runner.invoke(
+        main, ["--verbose", "harvest", "ogm"], obj={"START_TIME": perf_counter()}
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_harvest_ogm_include_repositories_success(runner, mocked_ogm_harvester):
+    _result = runner.invoke(
+        main,
+        [
+            "--verbose",
+            "harvest",
+            "ogm",
+            "--include-repositories",
+            "repo1,repo2,  repo3",  # testing whitespace stripping
+        ],
+    )
+    args, kwargs = mocked_ogm_harvester.call_args
+    assert kwargs["include_repositories"] == ["repo1", "repo2", "repo3"]
+
+
+def test_cli_harvest_ogm_exclude_repositories_success(runner, mocked_ogm_harvester):
+    _result = runner.invoke(
+        main,
+        [
+            "--verbose",
+            "harvest",
+            "ogm",
+            "--exclude-repositories",
+            "  repo1,repo2   ,repo3",  # testing whitespace stripping
+        ],
+    )
+    args, kwargs = mocked_ogm_harvester.call_args
+    assert kwargs["exclude_repositories"] == ["repo1", "repo2", "repo3"]


### PR DESCRIPTION
### Purpose and background context

This PR fills out the stubbed OGM harvest command in click CLI commands, making the CLI ready when records normalization is complete for OGM harvests.

### How can a reviewer manually see the effects of these changes?

Set env vars:
```
WORKSPACE=dev
SENTRY_DSN=None
S3_RESTRICTED_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/restricted/
S3_PUBLIC_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/public/
GEOHARVESTER_SQS_TOPIC_NAME=geo-harvester-input-dev
```

It is now possible to run an OGM harvest via the CLI, that should produce some output indicating it has started:

```shell
pipenv run harvester --verbose harvest \
--harvest-type=incremental \
--from-date=2024-01-10 \
ogm
```

This will throw some errors, as the normalization logic is not complete, but it can be seen the harvest has started, with arguments like `--from-date` getting used as expected.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-109

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

