### PR TITLE
Remove bbox requirement from MITAardvark and add WKT validator

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ lxml = "*"
 jsonlines = "*"
 pycountry = "*"
 pygit2 = "*"
+shapely = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc2ed28ed99ed60e109b4a033b20975a9be888bacf6a755195c07967f6ad1dfd"
+            "sha256": "0c732b491b9bde0b3a8bb1ca443d449f81774d10ae44738d3c4f6afebbe36b55"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:33a8b6d9136fa7427160edb92d2e50f2035f04e9d63a2d1027349053e12626aa",
-                "sha256:b2f321e20966f021ec800b7f2c01287a3dd04fc5965acdfbaa9c505a24ca45d1"
+                "sha256:4052031f9ac18924e94be7c30a5f0af5843a4752b8c8cb9034cd978be252b61b",
+                "sha256:53897701ab4f307fbcfdade673eae809dfc5eabb6102053c84907aa27de66e53"
             ],
             "index": "pypi",
-            "version": "==1.34.34"
+            "version": "==1.34.35"
         },
         "botocore": {
             "hashes": [
-                "sha256:54093dc97372bb7683f5c61a279aa8240408abf3b2cc494ae82a9a90c1b784b5",
-                "sha256:cd060b0d88ebb2b893f1411c1db7f2ba66cc18e52dcc57ad029564ef5fec437b"
+                "sha256:8a2b53ab772584a5f7e2fe1e4a59028b0602cfef8e39d622db7c6b670e4b1ee6",
+                "sha256:b67b8c865973202dc655a493317ae14b33d115e49ed6960874eb05d950167b37"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.34"
+            "version": "==1.34.35"
         },
         "certifi": {
             "hashes": [
@@ -229,6 +229,48 @@
             ],
             "index": "pypi",
             "version": "==5.1.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:02f98011ba4ab17f46f80f7f8f1c291ee7d855fcef0a5a98db80767a468c85cd",
+                "sha256:0b7e807d6888da0db6e7e75838444d62495e2b588b99e90dd80c3459594e857b",
+                "sha256:12c70ac274b32bc00c7f61b515126c9205323703abb99cd41836e8125ea0043e",
+                "sha256:1666f634cb3c80ccbd77ec97bc17337718f56d6658acf5d3b906ca03e90ce87f",
+                "sha256:18c3319a7d39b2c6a9e3bb75aab2304ab79a811ac0168a671a62e6346c29b03f",
+                "sha256:211ddd1e94817ed2d175b60b6374120244a4dd2287f4ece45d49228b4d529178",
+                "sha256:21a9484e75ad018974a2fdaa216524d64ed4212e418e0a551a2d83403b0531d3",
+                "sha256:39763aee6dfdd4878032361b30b2b12593fb445ddb66bbac802e2113eb8a6ac4",
+                "sha256:3c67423b3703f8fbd90f5adaa37f85b5794d3366948efe9a5190a5f3a83fc34e",
+                "sha256:46f47ee566d98849323f01b349d58f2557f02167ee301e5e28809a8c0e27a2d0",
+                "sha256:51c7f1b344f302067b02e0f5b5d2daa9ed4a721cf49f070280ac202738ea7f00",
+                "sha256:5f24750ef94d56ce6e33e4019a8a4d68cfdb1ef661a52cdaee628a56d2437419",
+                "sha256:697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4",
+                "sha256:6d45b3ec2faed4baca41c76617fcdcfa4f684ff7a151ce6fc78ad3b6e85af0a6",
+                "sha256:77810ef29e0fb1d289d225cabb9ee6cf4d11978a00bb99f7f8ec2132a84e0166",
+                "sha256:7ca4f24341df071877849eb2034948459ce3a07915c2734f1abb4018d9c49d7b",
+                "sha256:7f784e13e598e9594750b2ef6729bcd5a47f6cfe4a12cca13def35e06d8163e3",
+                "sha256:806dd64230dbbfaca8a27faa64e2f414bf1c6622ab78cc4264f7f5f028fee3bf",
+                "sha256:867e3644e208c8922a3be26fc6bbf112a035f50f0a86497f98f228c50c607bb2",
+                "sha256:8c66d6fec467e8c0f975818c1796d25c53521124b7cfb760114be0abad53a0a2",
+                "sha256:8ed07a90f5450d99dad60d3799f9c03c6566709bd53b497eb9ccad9a55867f36",
+                "sha256:9bc6d1a7f8cedd519c4b7b1156d98e051b726bf160715b769106661d567b3f03",
+                "sha256:9e1591f6ae98bcfac2a4bbf9221c0b92ab49762228f38287f6eeb5f3f55905ce",
+                "sha256:9e87562b91f68dd8b1c39149d0323b42e0082db7ddb8e934ab4c292094d575d6",
+                "sha256:a7081fd19a6d573e1a05e600c82a1c421011db7935ed0d5c483e9dd96b99cf13",
+                "sha256:a8474703bffc65ca15853d5fd4d06b18138ae90c17c8d12169968e998e448bb5",
+                "sha256:af36e0aa45e25c9f57bf684b1175e59ea05d9a7d3e8e87b7ae1a1da246f2767e",
+                "sha256:b1240f767f69d7c4c8a29adde2310b871153df9b26b5cb2b54a561ac85146485",
+                "sha256:b4d362e17bcb0011738c2d83e0a65ea8ce627057b2fdda37678f4374a382a137",
+                "sha256:b831295e5472954104ecb46cd98c08b98b49c69fdb7040483aff799a755a7374",
+                "sha256:b8c275f0ae90069496068c714387b4a0eba5d531aace269559ff2b43655edd58",
+                "sha256:bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b",
+                "sha256:cc0743f0302b94f397a4a65a660d4cd24267439eb16493fb3caad2e4389bccbb",
+                "sha256:da4b0c6c699a0ad73c810736303f7fbae483bcb012e38d7eb06a5e3b432c981b",
+                "sha256:f25e2811a9c932e43943a2615e65fc487a0b6b49218899e62e426e7f0a57eeda",
+                "sha256:f73497e8c38295aaa4741bdfa4fda1a5aedda5473074369eca10626835445511"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.26.3"
         },
         "pycountry": {
             "hashes": [
@@ -421,6 +463,53 @@
             "index": "pypi",
             "version": "==1.40.0"
         },
+        "shapely": {
+            "hashes": [
+                "sha256:03e63a99dfe6bd3beb8d5f41ec2086585bb969991d603f9aeac335ad396a06d4",
+                "sha256:0521d76d1e8af01e712db71da9096b484f081e539d4f4a8c97342e7971d5e1b4",
+                "sha256:06f193091a7c6112fc08dfd195a1e3846a64306f890b151fa8c63b3e3624202c",
+                "sha256:084b023dae8ad3d5b98acee9d3bf098fdf688eb0bb9b1401e8b075f6a627b611",
+                "sha256:1713cc04c171baffc5b259ba8531c58acc2a301707b7f021d88a15ed090649e7",
+                "sha256:1f217d28ecb48e593beae20a0082a95bd9898d82d14b8fcb497edf6bff9a44d7",
+                "sha256:2d217e56ae067e87b4e1731d0dc62eebe887ced729ba5c2d4590e9e3e9fdbd88",
+                "sha256:34eac2337cbd67650248761b140d2535855d21b969d76d76123317882d3a0c1a",
+                "sha256:36480e32c434d168cdf2f5e9862c84aaf4d714a43a8465ae3ce8ff327f0affb7",
+                "sha256:394e5085b49334fd5b94fa89c086edfb39c3ecab7f669e8b2a4298b9d523b3a5",
+                "sha256:42997ac806e4583dad51c80a32d38570fd9a3d4778f5e2c98f9090aa7db0fe91",
+                "sha256:45ac6906cff0765455a7b49c1670af6e230c419507c13e2f75db638c8fc6f3bd",
+                "sha256:4ef753200cbffd4f652efb2c528c5474e5a14341a473994d90ad0606522a46a2",
+                "sha256:5324be299d4c533ecfcfd43424dfd12f9428fd6f12cda38a4316da001d6ef0ea",
+                "sha256:5b0c052709c8a257c93b0d4943b0b7a3035f87e2d6a8ac9407b6a992d206422f",
+                "sha256:6a21353d28209fb0d8cc083e08ca53c52666e0d8a1f9bbe23b6063967d89ed24",
+                "sha256:6ca8cffbe84ddde8f52b297b53f8e0687bd31141abb2c373fd8a9f032df415d6",
+                "sha256:72b5997272ae8c25f0fd5b3b967b3237e87fab7978b8d6cd5fa748770f0c5d68",
+                "sha256:737dba15011e5a9b54a8302f1748b62daa207c9bc06f820cd0ad32a041f1c6f2",
+                "sha256:78128357a0cee573257a0c2c388d4b7bf13cb7dbe5b3fe5d26d45ebbe2a39e25",
+                "sha256:794affd80ca0f2c536fc948a3afa90bd8fb61ebe37fe873483ae818e7f21def4",
+                "sha256:7e92e7c255f89f5cdf777690313311f422aa8ada9a3205b187113274e0135cd8",
+                "sha256:87dc2be34ac3a3a4a319b963c507ac06682978a5e6c93d71917618b14f13066e",
+                "sha256:94ac128ae2ab4edd0bffcd4e566411ea7bdc738aeaf92c32a8a836abad725f9f",
+                "sha256:a5533a925d8e211d07636ffc2fdd9a7f9f13d54686d00577eeb11d16f00be9c4",
+                "sha256:a9a41ff4323fc9d6257759c26eb1cf3a61ebc7e611e024e6091f42977303fd3a",
+                "sha256:b8eb0a92f7b8c74f9d8fdd1b40d395113f59bd8132ca1348ebcc1f5aece94b96",
+                "sha256:baa14fc27771e180c06b499a0a7ba697c7988c7b2b6cba9a929a19a4d2762de3",
+                "sha256:be46d5509b9251dd9087768eaf35a71360de6afac82ce87c636990a0871aa18b",
+                "sha256:c6fd29fbd9cd76350bd5cc14c49de394a31770aed02d74203e23b928f3d2f1aa",
+                "sha256:ccfd5fa10a37e67dbafc601c1ddbcbbfef70d34c3f6b0efc866ddbdb55893a6c",
+                "sha256:d41a116fcad58048d7143ddb01285e1a8780df6dc1f56c3b1e1b7f12ed296651",
+                "sha256:dc9342fc82e374130db86a955c3c4525bfbf315a248af8277a913f30911bed9e",
+                "sha256:dea9a0651333cf96ef5bb2035044e3ad6a54f87d90e50fe4c2636debf1b77abc",
+                "sha256:e7c95d3379ae3abb74058938a9fcbc478c6b2e28d20dace38f8b5c587dde90aa",
+                "sha256:e7d897e6bdc6bc64f7f65155dbbb30e49acaabbd0d9266b9b4041f87d6e52b3a",
+                "sha256:ea84d1cdbcf31e619d672b53c4532f06253894185ee7acb8ceb78f5f33cbe033",
+                "sha256:ed1e99702125e7baccf401830a3b94d810d5c70b329b765fe93451fe14cf565b",
+                "sha256:eebe544df5c018134f3c23b6515877f7e4cd72851f88a8d0c18464f414d141a2",
+                "sha256:fa3ee28f5e63a130ec5af4dc3c4cb9c21c5788bb13c15e89190d163b14f9fb89",
+                "sha256:fd3ad17b64466a033848c26cb5b509625c87d07dcf39a1541461cacdb8f7e91c"
+            ],
+            "index": "pypi",
+            "version": "==2.0.2"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -492,11 +581,11 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:33a8b6d9136fa7427160edb92d2e50f2035f04e9d63a2d1027349053e12626aa",
-                "sha256:b2f321e20966f021ec800b7f2c01287a3dd04fc5965acdfbaa9c505a24ca45d1"
+                "sha256:4052031f9ac18924e94be7c30a5f0af5843a4752b8c8cb9034cd978be252b61b",
+                "sha256:53897701ab4f307fbcfdade673eae809dfc5eabb6102053c84907aa27de66e53"
             ],
             "index": "pypi",
-            "version": "==1.34.34"
+            "version": "==1.34.35"
         },
         "boto3-stubs": {
             "extras": [
@@ -505,19 +594,19 @@
                 "sqs"
             ],
             "hashes": [
-                "sha256:21da2f7f68205c1f5ec05e09709ec4b3f97ffcdb5e5f09e0ece7a1f36ad797cf",
-                "sha256:96789d5bdbd9ee10dca6512c7707a07cf52ef7b1aeab792a942c7d6b1317d3dc"
+                "sha256:91725aec6109f9b4d1d37a50e7c9478ce9caf41d5bd7debe80a31ec3e1f84a50",
+                "sha256:b88e0a93e777bdbb9f2f965b7800f9f1fc9624f46d6af1a0032fba9a36690c43"
             ],
             "index": "pypi",
-            "version": "==1.34.34"
+            "version": "==1.34.35"
         },
         "botocore": {
             "hashes": [
-                "sha256:54093dc97372bb7683f5c61a279aa8240408abf3b2cc494ae82a9a90c1b784b5",
-                "sha256:cd060b0d88ebb2b893f1411c1db7f2ba66cc18e52dcc57ad029564ef5fec437b"
+                "sha256:8a2b53ab772584a5f7e2fe1e4a59028b0602cfef8e39d622db7c6b670e4b1ee6",
+                "sha256:b67b8c865973202dc655a493317ae14b33d115e49ed6960874eb05d950167b37"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.34"
+            "version": "==1.34.35"
         },
         "botocore-stubs": {
             "hashes": [
@@ -992,11 +1081,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:1d01de681da1453335ec09ba43db521e577cbd58d25ddfb61e5965534b8be539",
-                "sha256:4a94a147ee70e85e0842da8d1093728c66085165775d1d302f0f77538bf92b95"
+                "sha256:62b9798aef9028432194cebb7a671f4064257bb3be662d9c1b83b94411b694bb",
+                "sha256:94e3b07a403cc8078ffee94bf404ef677112d036a57ddb5e0f19c5fcf48987f5"
             ],
             "index": "pypi",
-            "version": "==5.0.0"
+            "version": "==5.0.1"
         },
         "mypy": {
             "hashes": [

--- a/harvester/records/exceptions.py
+++ b/harvester/records/exceptions.py
@@ -4,6 +4,10 @@ import traceback
 from jsonschema.exceptions import ValidationError
 
 
+class FieldValueInvalidWarning(Warning):
+    """Warning to log when a validator determines field method returns an invalid value"""
+
+
 class FieldMethodError(Exception):
     """Exception to raise from normalize() method"""
 

--- a/harvester/records/fgdc.py
+++ b/harvester/records/fgdc.py
@@ -11,6 +11,7 @@ from dateutil.parser import ParserError
 from lxml import etree
 
 from harvester.records.record import XMLSourceRecord
+from harvester.records.validators import ValidateGeoshapeWKT
 from harvester.utils import convert_lang_code, date_parser, dedupe_list_of_values
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,10 @@ class FGDC(XMLSourceRecord):
                 mapped_values.append(mapped_value)  # noqa: PERF401
         return mapped_values
 
+    ##########################
+    # Optional Field Methods
+    ##########################
+    @ValidateGeoshapeWKT
     def _dcat_bbox(self) -> str:
         """Field method: dcat_bbox.
 
@@ -119,16 +124,6 @@ class FGDC(XMLSourceRecord):
         )
         return f"ENVELOPE({lat_lon_envelope})"
 
-    def _locn_geometry(self) -> str:
-        """Field method: locn_geometry
-
-        NOTE: at this time, duplicating bounding box content from dcat_bbox
-        """
-        return self._dcat_bbox()
-
-    ##########################
-    # Optional Field Methods
-    ##########################
     def _dct_identifier_sm(self) -> list[str]:
         identifiers = []
 
@@ -384,3 +379,10 @@ class FGDC(XMLSourceRecord):
                         /sdtstype
         """
         return self.string_list_from_xpath(xpath_expr)
+
+    def _locn_geometry(self) -> str | None:
+        """Field method: locn_geometry
+
+        NOTE: at this time, duplicating bounding box content from dcat_bbox
+        """
+        return self._dcat_bbox()

--- a/harvester/records/iso19139.py
+++ b/harvester/records/iso19139.py
@@ -13,6 +13,7 @@ from dateutil.parser import parse as date_parser
 from lxml import etree
 
 from harvester.records.record import XMLSourceRecord
+from harvester.records.validators import ValidateGeoshapeWKT
 from harvester.utils import convert_lang_code
 
 logger = logging.getLogger(__name__)
@@ -142,7 +143,11 @@ class ISO19139(XMLSourceRecord):
                 output.append(mapped_value)
         return output
 
-    def _dcat_bbox(self) -> str:
+    ##########################
+    # Optional Field Methods
+    ##########################
+    @ValidateGeoshapeWKT
+    def _dcat_bbox(self) -> str | None:
         """Field method: dcat_bbox.
 
         "bbox" stands for "Bounding Box", and it should be the largest possible rectangle
@@ -187,16 +192,6 @@ class ISO19139(XMLSourceRecord):
 
         return f"ENVELOPE({lat_lon_envelope})"
 
-    def _locn_geometry(self) -> str:
-        """Field method: locn_geometry
-
-        NOTE: at this time, duplicating bounding box content from dcat_bbox
-        """
-        return self._dcat_bbox()
-
-    ##########################
-    # Optional Field Methods
-    ##########################
     def _dct_description_sm(self) -> list[str]:
         xpath_expr = """
         //gmd:MD_Metadata
@@ -465,6 +460,13 @@ class ISO19139(XMLSourceRecord):
                 logger.debug(message)
                 continue
         return years
+
+    def _locn_geometry(self) -> str | None:
+        """Field method: locn_geometry
+
+        NOTE: at this time, duplicating bounding box content from dcat_bbox
+        """
+        return self._dcat_bbox()
 
     ##########################
     # Utility / Helper Methods

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -5,20 +5,17 @@
 import datetime
 import json
 import logging
-import os
 from abc import abstractmethod
 from typing import Any, Literal
 
 from attrs import asdict, define, field, fields
 from attrs.validators import in_, instance_of
-from jsonschema import FormatChecker
-from jsonschema.validators import Draft202012Validator
 from lxml import etree  # type: ignore[import-untyped]
-from referencing import Registry, Resource
 
 from harvester.aws.sqs import ZipFileEventMessage
 from harvester.config import Config
-from harvester.records.exceptions import FieldMethodError, JSONSchemaValidationError
+from harvester.records.exceptions import FieldMethodError
+from harvester.records.validators import MITAardvarkFormatValidator
 from harvester.utils import dedupe_list_of_values
 
 logger = logging.getLogger(__name__)
@@ -112,83 +109,7 @@ class MITAardvark:
         The JSON schema validation is performed in addition to the validation of
         arguments through attrs attribute validators.
         """
-        self.validate()
-
-    @property
-    def json_schemas(self) -> dict:
-        """Load JSON schemas for validating MITAardvark records.
-
-        To validate MITAardvark records, the validator relies on two schemas:
-           * MITAardvark schema;
-           * OpenGeoMetadata's (OGM) Geoblacklight Aardvark schema.
-
-        The MITAardvark schema will comprise of majority of OGM's Aardvark schema,
-        with several updates for MIT's purposes. The schemas are read from
-        harvester/records/schemas directory and later added to a referencing.Registry.
-        Once in the registry, the validator can use the schemas to validate data.
-
-        Returns:
-            dict: JSON schemas for validating MITAardvark records.
-        """
-        schemas = {}
-        schema_dir = os.path.join(os.path.dirname(__file__), "schemas")
-        with open(schema_dir + "/mit-schema-aardvark.json") as f:
-            schemas["mit-schema-aardvark"] = json.loads(f.read())
-        with open(schema_dir + "/geoblacklight-schema-aardvark.json") as f:
-            schemas["geoblacklight-schema-aardvark"] = json.loads(f.read())
-        return schemas
-
-    @property
-    def validator(self) -> Draft202012Validator:
-        """Create a validator with JSON schemas for evaluating MITAardvark records.
-
-        An instance referencing.Registry is created with the required schema added as
-        resources. When the validator is created, the registry is included as an argument.
-        This enables the validator to use the schemas for validation.
-
-        Note: For more information on
-            * registries: https://python-jsonschema.readthedocs.io/en/stable/referencing
-            * validators: https://python-jsonschema.readthedocs.io/en/stable/validate/#the-validator-protocol
-
-        Returns:
-            Draft202012Validator: JSON schema validator with MITAardvark and OGM Aardvark
-                schemas.
-        """
-        registry: Registry = Registry().with_resources(
-            [
-                (
-                    "mit-schema-aardvark",
-                    Resource.from_contents(self.json_schemas["mit-schema-aardvark"]),
-                ),
-                (
-                    "geoblacklight-schema-aardvark",
-                    Resource.from_contents(
-                        self.json_schemas["geoblacklight-schema-aardvark"]
-                    ),
-                ),
-            ]
-        )
-        return Draft202012Validator(
-            schema=self.json_schemas["mit-schema-aardvark"],
-            registry=registry,
-            format_checker=FormatChecker(),
-        )
-
-    def validate(self) -> None:
-        """Validate that Aardvark is compliant for MIT purposes.
-
-        The validator is retrieved in order to use .iter_errors() to iterate through
-        each of the validation errors in the normalized record. If there are any errors,
-        they are compiled into a single error message that appears in a
-        JSONSchemaValidationError exception.
-        """
-        validation_errors = sorted(self.validator.iter_errors(self.to_dict()), key=str)
-
-        if validation_errors:
-            exc = JSONSchemaValidationError(validation_errors)
-            logger.debug(exc.message)
-            raise exc
-        logger.debug("The normalized MITAardvark record is valid")
+        MITAardvarkFormatValidator(self.to_dict()).validate()
 
     def to_dict(self) -> dict:
         """Dump MITAardvark record to dictionary."""

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -67,11 +67,10 @@ class MITAardvark:
     id: str
 
     # additional MIT required fields
-    dcat_bbox: str
     dct_references_s: str
-    locn_geometry: str
 
     # optional fields
+    dcat_bbox: str = field(default=None)
     dcat_centroid: str = field(default=None)
     dcat_keyword_sm: list = field(default=None)
     dcat_theme_sm: list = field(default=None)
@@ -103,6 +102,7 @@ class MITAardvark:
     gbl_resourceType_sm: list = field(default=None)
     gbl_suppressed_b: bool = field(default=None)
     gbl_wxsIdentifier_s: str = field(default=None)
+    locn_geometry: str = field(default=None)
     pcdm_memberOf_sm: list = field(default=None)
     schema_provider_s: str = field(default=None)
 
@@ -359,14 +359,6 @@ class SourceRecord:
 
     @abstractmethod
     def _gbl_resourceClass_sm(self) -> list[str] | None:
-        pass  # pragma: nocover
-
-    @abstractmethod
-    def _dcat_bbox(self) -> str:
-        pass  # pragma: nocover
-
-    @abstractmethod
-    def _locn_geometry(self) -> str:
         pass  # pragma: nocover
 
     ####################################

--- a/harvester/records/schemas/mit-schema-aardvark.json
+++ b/harvester/records/schemas/mit-schema-aardvark.json
@@ -131,14 +131,12 @@
         }
     },
     "required": [
-        "dcat_bbox",
         "dct_accessRights_s",
         "dct_references_s",
         "dct_title_s",
         "gbl_mdModified_dt",
         "gbl_mdVersion_s",
         "gbl_resourceClass_sm",
-        "id",
-        "locn_geometry"
+        "id"
     ]
 }

--- a/harvester/records/validators.py
+++ b/harvester/records/validators.py
@@ -1,0 +1,71 @@
+import logging
+import re
+from ast import literal_eval
+from collections.abc import Callable
+from functools import partial, update_wrapper
+
+import shapely
+
+from harvester.records.exceptions import FieldValueInvalidWarning
+
+logger = logging.getLogger(__name__)
+
+
+##########################
+# Data Validators
+##########################
+class ValidateGeoshapeWKT:
+    """Decorator class for validating geoshape WKT values.
+
+    The validator should be applied to any field methods that retrieve geoshape
+    WKT values. The validator logs a warning if the WKT value cannot be parsed
+    using the shapely module. If the WKT value cannot be parsed, the validator
+    resets the value to None.
+    """
+
+    invalid_wkt_warning_message: str = (
+        "field: {field_name}, shapely was unable to parse WKT: '{value}'; "
+        "setting value to None"
+    )
+
+    def __init__(self, field_method: Callable):
+        update_wrapper(self, field_method)
+        self.field_method = field_method
+
+    def __call__(self, obj: object) -> str | None:
+        field_name = self.field_method.__name__.removeprefix("_")
+        value = self.field_method(obj)
+
+        try:
+            self.create_geoshape(value)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                FieldValueInvalidWarning(
+                    self.invalid_wkt_warning_message.format(
+                        field_name=field_name, value=value
+                    )
+                )
+            )
+            return None
+        return value
+
+    def __get__(self, obj: object, _: type) -> partial[str | None]:
+        """Required by decorator to access SourceRecord instance"""
+        return partial(self.__call__, obj)
+
+    @staticmethod
+    def create_geoshape(wkt: str) -> shapely.Geometry:
+        """Run shapely to determine whether geoshape WKT value is valid.
+
+        If the geoshape WKT value is valid, shapely can successfully create a
+        geometry object.
+
+        Note: shapely does not currently support WKT values for bounding box regions or
+        envelopes. The method uses regex to retrieving the vertices for a geoshape WKT
+        value with the format: "ENVELOPE(<vertices>)". The regex retrieves the vertices
+        inside the parentheses and passes the vertices as arguments to shapely.box().
+        """
+        if geoshape_string := re.compile(r"^ENVELOPE\s?(.*)").match(wkt):
+            xmin, xmax, ymax, ymin = literal_eval(geoshape_string.group(1))
+            return shapely.box(xmin, ymin, xmax, ymax)
+        return shapely.from_wkt(wkt)

--- a/harvester/records/validators.py
+++ b/harvester/records/validators.py
@@ -1,19 +1,28 @@
+import json
 import logging
+import os
 import re
 from ast import literal_eval
 from collections.abc import Callable
 from functools import partial, update_wrapper
 
 import shapely
+from attrs import define
+from jsonschema import FormatChecker
+from jsonschema.validators import Draft202012Validator
+from referencing import Registry, Resource
 
-from harvester.records.exceptions import FieldValueInvalidWarning
+from harvester.records.exceptions import (
+    FieldValueInvalidWarning,
+    JSONSchemaValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
 
-##########################
+###################
 # Data Validators
-##########################
+###################
 class ValidateGeoshapeWKT:
     """Decorator class for validating geoshape WKT values.
 
@@ -69,3 +78,90 @@ class ValidateGeoshapeWKT:
             xmin, xmax, ymax, ymin = literal_eval(geoshape_string.group(1))
             return shapely.box(xmin, ymin, xmax, ymax)
         return shapely.from_wkt(wkt)
+
+
+#####################
+# Format Validators
+#####################
+@define
+class MITAardvarkFormatValidator:
+    """MITAardvark format validator class."""
+
+    normalized_record: dict
+
+    @property
+    def jsonschemas(self) -> dict:
+        """Load JSON schemas for validating MITAardvark records.
+
+        To validate MITAardvark records, the validator relies on two schemas:
+           * MITAardvark schema;
+           * OpenGeoMetadata's (OGM) Geoblacklight Aardvark schema.
+
+        The MITAardvark schema will comprise of majority of OGM's Aardvark schema,
+        with several updates for MIT's purposes. The schemas are read from
+        harvester/records/schemas directory and later added to a referencing.Registry.
+        Once in the registry, the validator can use the schemas to validate data.
+
+        Returns:
+            dict: JSON schemas for validating MITAardvark records.
+        """
+        schemas = {}
+        schema_dir = os.path.join(os.path.dirname(__file__), "schemas")
+        with open(schema_dir + "/mit-schema-aardvark.json") as f:
+            schemas["mit-schema-aardvark"] = json.loads(f.read())
+        with open(schema_dir + "/geoblacklight-schema-aardvark.json") as f:
+            schemas["geoblacklight-schema-aardvark"] = json.loads(f.read())
+        return schemas
+
+    @property
+    def jsonschema_validator(self) -> Draft202012Validator:
+        """Create a validator with JSON schemas for evaluating MITAardvark records.
+
+        An instance referencing.Registry is created with the required schema added as
+        resources. When the validator is created, the registry is included as an argument.
+        This enables the validator to use the schemas for validation.
+
+        Note: For more information on
+            * registries: https://python-jsonschema.readthedocs.io/en/stable/referencing
+            * validators: https://python-jsonschema.readthedocs.io/en/stable/validate/#the-validator-protocol
+
+        Returns:
+            Draft202012Validator: JSON schema validator with MITAardvark and OGM Aardvark
+                schemas.
+        """
+        registry: Registry = Registry().with_resources(
+            [
+                (
+                    "mit-schema-aardvark",
+                    Resource.from_contents(self.jsonschemas["mit-schema-aardvark"]),
+                ),
+                (
+                    "geoblacklight-schema-aardvark",
+                    Resource.from_contents(
+                        self.jsonschemas["geoblacklight-schema-aardvark"]
+                    ),
+                ),
+            ]
+        )
+        return Draft202012Validator(
+            schema=self.jsonschemas["mit-schema-aardvark"],
+            registry=registry,
+            format_checker=FormatChecker(),
+        )
+
+    def validate(self) -> None:
+        """Validate format of MITAardvark record using JSON schema.
+
+        The validator is retrieved in order to use .iter_errors() to iterate through
+        each of the validation errors in the normalized record. If there are any errors,
+        they are compiled into a single error message that appears in a
+        JSONSchemaValidationError exception.
+        """
+        if schema_validation_errors := sorted(
+            self.jsonschema_validator.iter_errors(self.normalized_record),
+            key=str,
+        ):
+            validation_error = JSONSchemaValidationError(schema_validation_errors)
+            logger.error(validation_error)
+            raise validation_error
+        logger.debug("The normalized MITAardvark record is valid")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ disallow_untyped_calls = true
 disallow_untyped_defs = true
 exclude = ["tests/", "output/"]
 
+[[tool.mypy.overrides]]
+module = ["shapely"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 log_level = "INFO"
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,13 +229,7 @@ def mocked_required_fields_source_record(valid_generic_xml_source_record):
         def _id(self):
             return mocked_value
 
-        def _dcat_bbox(self):
-            return mocked_value
-
         def _dct_references_s(self):
-            return mocked_value
-
-        def _locn_geometry(self):
             return mocked_value
 
     return TestXMLSourceRecord(
@@ -257,9 +251,7 @@ def valid_mitaardvark_data_required_fields():
         "gbl_mdVersion_s": "Aardvark",
         "gbl_resourceClass_sm": ["Datasets"],
         "id": "value here",
-        "dcat_bbox": "value here",
         "dct_references_s": "value here",
-        "locn_geometry": "value here",
     }
 
 
@@ -282,9 +274,7 @@ def invalid_mitaardvark_data_required_fields():
         "gbl_mdVersion_s": "Invalid",
         "gbl_resourceClass_sm": ["Invalid"],
         "id": 1,
-        "dcat_bbox": "value here",
         "dct_references_s": "value here",
-        "locn_geometry": "value here",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from harvester.harvest import Harvester
 from harvester.harvest.mit import MITHarvester
 from harvester.harvest.ogm import OGMHarvester, OGMRepository
 from harvester.records import FGDC, ISO19139, MITAardvark, Record, XMLSourceRecord
+from harvester.records.validators import ValidateGeoshapeWKT
 
 
 @pytest.fixture(autouse=True)
@@ -240,6 +241,21 @@ def mocked_required_fields_source_record(valid_generic_xml_source_record):
         event=valid_generic_xml_source_record.event,
         nsmap=valid_generic_xml_source_record.nsmap,
     )
+
+
+@pytest.fixture
+def mocked_validated_fields_source_record():
+    class TestValidatedSourceRecord:
+        mocked_value = ""
+
+        @ValidateGeoshapeWKT
+        def _dcat_bbox(self):
+            return self.mocked_value
+
+        def _locn_geometry(self):
+            return self._dcat_bbox()
+
+    return TestValidatedSourceRecord
 
 
 @pytest.fixture

--- a/tests/test_records/test_fgdc.py
+++ b/tests/test_records/test_fgdc.py
@@ -57,23 +57,14 @@ def test_fgdc_record_required_gbl_resourceClass_sm_unhandled_value_return_none(
     assert fgdc_source_record_required_fields._gbl_resourceClass_sm() == []
 
 
-def test_fgdc_record_required_dcat_bbox(fgdc_source_record_required_fields):
-    assert (
-        fgdc_source_record_required_fields._dcat_bbox()
-        == "ENVELOPE(31.161907, 31.381609, 30.141311, 29.994131)"
-    )
-
-
-def test_fgdc_record_required_locn_geometry(fgdc_source_record_required_fields):
-    assert (
-        fgdc_source_record_required_fields._locn_geometry()
-        == "ENVELOPE(31.161907, 31.381609, 30.141311, 29.994131)"
-    )
-
-
 #################################
 # Optional Fields
 #################################
+def test_fgdc_record_required_dcat_bbox(fgdc_source_record_all_fields):
+    assert (
+        fgdc_source_record_all_fields._dcat_bbox()
+        == "ENVELOPE(-74.041973, -73.832878, 40.739137, 40.569421)"
+    )
 
 
 def test_fgdc_optional_dct_identifier_sm(fgdc_source_record_all_fields):
@@ -251,3 +242,10 @@ def test_fgdc_optional_gbl_indexYear_im_date_parse_log_continue(
 
 def test_fgdc_optional_gbl_resourceType_sm(fgdc_source_record_all_fields):
     assert fgdc_source_record_all_fields._gbl_resourceType_sm() == ["G-polygon"]
+
+
+def test_fgdc_record_required_locn_geometry(fgdc_source_record_all_fields):
+    assert (
+        fgdc_source_record_all_fields._locn_geometry()
+        == "ENVELOPE(-74.041973, -73.832878, 40.739137, 40.569421)"
+    )

--- a/tests/test_records/test_iso19139.py
+++ b/tests/test_records/test_iso19139.py
@@ -62,23 +62,16 @@ def test_iso19139_record_required_gbl_resourceClass_sm_unhandled_value_return_no
     assert iso19139_source_record_required_fields._gbl_resourceClass_sm() == []
 
 
-def test_iso19139_record_required_dcat_bbox(iso19139_source_record_required_fields):
-    assert (
-        iso19139_source_record_required_fields._dcat_bbox()
-        == "ENVELOPE(88, 138, 25.833333, -16.5)"
-    )
-
-
-def test_iso19139_record_required_locn_geometry(iso19139_source_record_required_fields):
-    assert (
-        iso19139_source_record_required_fields._locn_geometry()
-        == "ENVELOPE(88, 138, 25.833333, -16.5)"
-    )
-
-
 #################################
 # Optional Fields
 #################################
+
+
+def test_iso19139_record_required_dcat_bbox(iso19139_source_record_all_fields):
+    assert (
+        iso19139_source_record_all_fields._dcat_bbox()
+        == "ENVELOPE(88, 138, 25.833333, -16.5)"
+    )
 
 
 def test_iso19139_optional_dcat_keyword_sm(iso19139_source_record_all_fields):
@@ -262,6 +255,13 @@ def test_iso19139_optional_gbl_indexYear_im_date_parse_log_continue(
 
 def test_iso19139_optional_gbl_resourceType_sm(iso19139_source_record_all_fields):
     assert iso19139_source_record_all_fields._gbl_resourceType_sm() == ["polygon"]
+
+
+def test_iso19139_record_required_locn_geometry(iso19139_source_record_all_fields):
+    assert (
+        iso19139_source_record_all_fields._locn_geometry()
+        == "ENVELOPE(88, 138, 25.833333, -16.5)"
+    )
 
 
 def test_iso19139_get_temporal_extents_instant_and_periods_success(

--- a/tests/test_records/test_validator.py
+++ b/tests/test_records/test_validator.py
@@ -1,98 +1,116 @@
-from harvester.records.validators import ValidateGeoshapeWKT
-
-
-def test_validator_envelope_returns_original_value_success(
-    caplog,
+def test_validator_envelope_none_nonetype_skips_validation_logs_warning_returns_none(
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
+    mocked_validated_fields_source_record.mocked_value = None
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    invalid_none_warning_message = (
+        "field: dcat_bbox, value of type NoneType was provided; "
+        "returning original value of None"
+    )
+    assert value is None
+    assert invalid_none_warning_message in caplog.text
 
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _dcat_bbox(self):
-            return "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
 
-    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
-    assert value == "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
-
-
-def test_validator_envelope_missing_vertices_logs_warning_and_sets_value_to_none(
-    caplog,
+def test_validator_envelope_none_string_skips_validation_logs_warning_returns_none(
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
-
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _dcat_bbox(self):
-            return "ENVELOPE()"
-
-    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
-    invalid_value_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse WKT: 'ENVELOPE()'; "
+    mocked_validated_fields_source_record.mocked_value = "None"
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse string as WKT: 'None'; "
         "setting value to None"
     )
     assert value is None
-    assert invalid_value_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text
 
 
-def test_validator_envelope_insufficient_vertices_logs_warning_and_sets_value_to_none(
-    caplog,
+def test_validator_envelope_nonstring_skips_validation_logs_warning_returns_none(
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
+    mocked_validated_fields_source_record.mocked_value = 999
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    invalid_type_warning_message = (
+        "field: dcat_bbox, value of type <class 'int'> was provided: 999; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_type_warning_message in caplog.text
 
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _dcat_bbox(self):
-            return "ENVELOPE(71.0589, 74.0060, 42.3601)"
 
-    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
-    invalid_value_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse WKT: "
+def test_validator_envelope_returns_original_value_success(
+    caplog, mocked_validated_fields_source_record
+):
+    caplog.set_level("DEBUG")
+    mocked_validated_fields_source_record.mocked_value = (
+        "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
+    )
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    assert value == "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
+
+
+def test_validator_envelope_missing_vertices_logs_warning_sets_value_to_none(
+    caplog, mocked_validated_fields_source_record
+):
+    caplog.set_level("DEBUG")
+    mocked_validated_fields_source_record.mocked_value = "ENVELOPE()"
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse string as WKT: 'ENVELOPE()'; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_wkt_warning_message in caplog.text
+
+
+def test_validator_envelope_insufficient_vertices_logs_warning_sets_value_to_none(
+    caplog, mocked_validated_fields_source_record
+):
+    caplog.set_level("DEBUG")
+    mocked_validated_fields_source_record.mocked_value = (
+        "ENVELOPE(71.0589, 74.0060, 42.3601)"
+    )
+    value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse string as WKT: "
         "'ENVELOPE(71.0589, 74.0060, 42.3601)'; "
         "setting value to None"
     )
     assert value is None
-    assert invalid_value_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text
 
 
 def test_validator_polygon_returns_original_value_success(
-    caplog,
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
     polygon_wkt = (
         "POLYGON ((74.0060 40.7128, 71.0589 42.3601, "
         "73.7562 42.6526, 74.0060 40.7128))"
     )
-
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _locn_geometry(self):
-            return polygon_wkt
-
-    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    mocked_validated_fields_source_record.mocked_value = polygon_wkt
+    value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
     assert value == polygon_wkt
 
 
-def test_validator_polygon_missing_vertices_logs_warning_and_sets_value_to_none(
-    caplog,
+def test_validator_polygon_missing_vertices_logs_warning_sets_value_to_none(
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
-
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _locn_geometry(self):
-            return "POLYGON (())"
-
-    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
-    invalid_value_warning_message = (
-        "field: locn_geometry, shapely was unable to parse WKT: 'POLYGON (())'; "
+    mocked_validated_fields_source_record.mocked_value = "POLYGON (())"
+    value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse string as WKT: 'POLYGON (())'; "
         "setting value to None"
     )
     assert value is None
-    assert invalid_value_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text
 
 
 def test_validator_multipolygon_returns_original_value_success(
-    caplog,
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
     multipolygon_wkt = (
@@ -101,31 +119,21 @@ def test_validator_multipolygon_returns_original_value_success(
         "41.7658 72.6734)), ((73.9776 40.7614, 73.9554 40.7827, 73.9631 40.7812, "
         "73.9776 40.7614)))"
     )
-
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _locn_geometry(self):
-            return multipolygon_wkt
-
-    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    mocked_validated_fields_source_record.mocked_value = multipolygon_wkt
+    value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
     assert value == multipolygon_wkt
 
 
-def test_validator_multipolygon_missing_vertices_logs_warning_and_sets_value_to_none(
-    caplog,
+def test_validator_multipolygon_missing_vertices_logs_warning_sets_value_to_none(
+    caplog, mocked_validated_fields_source_record
 ):
     caplog.set_level("DEBUG")
-
-    class TestValidatedXMLSourceRecord:
-        @ValidateGeoshapeWKT
-        def _locn_geometry(self):
-            return "MULTIPOLYGON (((), ()), (()))"
-
-    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
-    invalid_value_warning_message = (
-        "field: locn_geometry, shapely was unable to parse WKT: "
+    mocked_validated_fields_source_record.mocked_value = "MULTIPOLYGON (((), ()), (()))"
+    value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse string as WKT: "
         "'MULTIPOLYGON (((), ()), (()))'; "
         "setting value to None"
     )
     assert value is None
-    assert invalid_value_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text

--- a/tests/test_records/test_validator.py
+++ b/tests/test_records/test_validator.py
@@ -4,12 +4,11 @@ def test_validator_envelope_none_nonetype_skips_validation_logs_warning_returns_
     caplog.set_level("DEBUG")
     mocked_validated_fields_source_record.mocked_value = None
     value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
-    invalid_none_warning_message = (
-        "field: dcat_bbox, value of type NoneType was provided; "
-        "returning original value of None"
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, unable to parse WKT from value: None; returning None"
     )
     assert value is None
-    assert invalid_none_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text
 
 
 def test_validator_envelope_none_string_skips_validation_logs_warning_returns_none(
@@ -19,8 +18,7 @@ def test_validator_envelope_none_string_skips_validation_logs_warning_returns_no
     mocked_validated_fields_source_record.mocked_value = "None"
     value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
     invalid_wkt_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse string as WKT: 'None'; "
-        "setting value to None"
+        "field: dcat_bbox, unable to parse WKT from value: None; returning None"
     )
     assert value is None
     assert invalid_wkt_warning_message in caplog.text
@@ -32,12 +30,11 @@ def test_validator_envelope_nonstring_skips_validation_logs_warning_returns_none
     caplog.set_level("DEBUG")
     mocked_validated_fields_source_record.mocked_value = 999
     value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
-    invalid_type_warning_message = (
-        "field: dcat_bbox, value of type <class 'int'> was provided: 999; "
-        "setting value to None"
+    invalid_wkt_warning_message = (
+        "field: dcat_bbox, unable to parse WKT from value: 999; returning None"
     )
     assert value is None
-    assert invalid_type_warning_message in caplog.text
+    assert invalid_wkt_warning_message in caplog.text
 
 
 def test_validator_envelope_returns_original_value_success(
@@ -58,8 +55,7 @@ def test_validator_envelope_missing_vertices_logs_warning_sets_value_to_none(
     mocked_validated_fields_source_record.mocked_value = "ENVELOPE()"
     value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
     invalid_wkt_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse string as WKT: 'ENVELOPE()'; "
-        "setting value to None"
+        "field: dcat_bbox, unable to parse WKT from value: ENVELOPE(); returning None"
     )
     assert value is None
     assert invalid_wkt_warning_message in caplog.text
@@ -74,9 +70,8 @@ def test_validator_envelope_insufficient_vertices_logs_warning_sets_value_to_non
     )
     value = mocked_validated_fields_source_record()._dcat_bbox()  # noqa: SLF001
     invalid_wkt_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse string as WKT: "
-        "'ENVELOPE(71.0589, 74.0060, 42.3601)'; "
-        "setting value to None"
+        "field: dcat_bbox, unable to parse WKT from value: "
+        "ENVELOPE(71.0589, 74.0060, 42.3601); returning None"
     )
     assert value is None
     assert invalid_wkt_warning_message in caplog.text
@@ -102,8 +97,8 @@ def test_validator_polygon_missing_vertices_logs_warning_sets_value_to_none(
     mocked_validated_fields_source_record.mocked_value = "POLYGON (())"
     value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
     invalid_wkt_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse string as WKT: 'POLYGON (())'; "
-        "setting value to None"
+        "field: dcat_bbox, unable to parse WKT from value: POLYGON (()); "
+        "returning None"
     )
     assert value is None
     assert invalid_wkt_warning_message in caplog.text
@@ -131,9 +126,8 @@ def test_validator_multipolygon_missing_vertices_logs_warning_sets_value_to_none
     mocked_validated_fields_source_record.mocked_value = "MULTIPOLYGON (((), ()), (()))"
     value = mocked_validated_fields_source_record()._locn_geometry()  # noqa: SLF001
     invalid_wkt_warning_message = (
-        "field: dcat_bbox, shapely was unable to parse string as WKT: "
-        "'MULTIPOLYGON (((), ()), (()))'; "
-        "setting value to None"
+        "field: dcat_bbox, unable to parse WKT from value: "
+        "MULTIPOLYGON (((), ()), (())); returning None"
     )
     assert value is None
     assert invalid_wkt_warning_message in caplog.text

--- a/tests/test_records/test_validator.py
+++ b/tests/test_records/test_validator.py
@@ -1,0 +1,131 @@
+from harvester.records.validators import ValidateGeoshapeWKT
+
+
+def test_validator_envelope_returns_original_value_success(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _dcat_bbox(self):
+            return "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
+
+    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
+    assert value == "ENVELOPE(71.0589, 74.0060, 42.3601, 40.7128)"
+
+
+def test_validator_envelope_missing_vertices_logs_warning_and_sets_value_to_none(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _dcat_bbox(self):
+            return "ENVELOPE()"
+
+    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
+    invalid_value_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse WKT: 'ENVELOPE()'; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_value_warning_message in caplog.text
+
+
+def test_validator_envelope_insufficient_vertices_logs_warning_and_sets_value_to_none(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _dcat_bbox(self):
+            return "ENVELOPE(71.0589, 74.0060, 42.3601)"
+
+    value = TestValidatedXMLSourceRecord()._dcat_bbox()  # noqa: SLF001
+    invalid_value_warning_message = (
+        "field: dcat_bbox, shapely was unable to parse WKT: "
+        "'ENVELOPE(71.0589, 74.0060, 42.3601)'; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_value_warning_message in caplog.text
+
+
+def test_validator_polygon_returns_original_value_success(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+    polygon_wkt = (
+        "POLYGON ((74.0060 40.7128, 71.0589 42.3601, "
+        "73.7562 42.6526, 74.0060 40.7128))"
+    )
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _locn_geometry(self):
+            return polygon_wkt
+
+    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    assert value == polygon_wkt
+
+
+def test_validator_polygon_missing_vertices_logs_warning_and_sets_value_to_none(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _locn_geometry(self):
+            return "POLYGON (())"
+
+    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    invalid_value_warning_message = (
+        "field: locn_geometry, shapely was unable to parse WKT: 'POLYGON (())'; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_value_warning_message in caplog.text
+
+
+def test_validator_multipolygon_returns_original_value_success(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+    multipolygon_wkt = (
+        "MULTIPOLYGON (((40.7128 74.0060, 42.3601 71.0589, 42.6526 73.7562, "
+        "40.7128 74.0060), (41.7658 72.6734, 41.5623 72.6506, 41.5582 73.0515, "
+        "41.7658 72.6734)), ((73.9776 40.7614, 73.9554 40.7827, 73.9631 40.7812, "
+        "73.9776 40.7614)))"
+    )
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _locn_geometry(self):
+            return multipolygon_wkt
+
+    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    assert value == multipolygon_wkt
+
+
+def test_validator_multipolygon_missing_vertices_logs_warning_and_sets_value_to_none(
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    class TestValidatedXMLSourceRecord:
+        @ValidateGeoshapeWKT
+        def _locn_geometry(self):
+            return "MULTIPOLYGON (((), ()), (()))"
+
+    value = TestValidatedXMLSourceRecord()._locn_geometry()  # noqa: SLF001
+    invalid_value_warning_message = (
+        "field: locn_geometry, shapely was unable to parse WKT: "
+        "'MULTIPOLYGON (((), ()), (()))'; "
+        "setting value to None"
+    )
+    assert value is None
+    assert invalid_value_warning_message in caplog.text


### PR DESCRIPTION
### Purpose and background context

This PR removes bounding box information as a requirement for MITAardvark records and adds a validator for well-known text (WKT) values for the `dcat_bbox` (and consequently, `locn_geometry`) geoshape fields. For review purposes, it might be good to view the work as two parts.

**Part 1: Removing bounding box information as a requirement for MITAardvark records**
The bulk of this work is done in the [first commit](https://github.com/MITLibraries/geo-harvester/pull/138/commits/e7fba4f1e971208d3b071ad0e9bed11c5de5c382#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128). Some minor updates to support this were also made in the [third commit](https://github.com/MITLibraries/geo-harvester/pull/138/commits/287478f8e1cf49489772e6c8bfabe61f48bdc6d2).

**Part 2: Adding WKT validator**
The `ValidateGeoshapeWKT` class is an example of how we can implement universal validation methods (i.e., usable for any field methods independent of `SourceRecord` type) moving forward. The proposed framework is to create [decorator classes](https://realpython.com/primer-on-python-decorators/#classes-as-decorators) representing validation methods and decorating `SourceRecord` field methods as-needed. 

1. We were interested if we could add any validation earlier on in the pipeline to address the most common errors we get from indexing TIMDEX records into OpenSearch.
   * (a): "at least three non-collinear points required"
   * (b): "invalid [latitude/longitude] <invalid-value>; must be between [-90.0 and 90.0/-180.0 and 180.0]"   

2. **ValidateGeoshapeWKT:** After initial testing and discussion (with @ghukill ), **it was decided that we would limit the validation to "Is this value a valid WKT string?"** There was some code earlier on that took another step forward to check if the "geometry" object (as `shapely` refers to it) is valid--using the [shapely.is_valid](https://shapely.readthedocs.io/en/stable/reference/shapely.is_valid.html) and [shapely.is_valid_reason](https://shapely.readthedocs.io/en/stable/reference/shapely.is_valid_reason.html#shapely.is_valid_reason) methods. 

   Of the two most common errors described above, it would've only addressed (a). That said, we felt we would need to have a deeper understanding of `shapely` before using it. That is when we decided to take a step back and keep the validation simple.

### How can a reviewer manually see the effects of these changes?

1. Review tests in `geo-harvester/tests/test_records/test_validator.py`.
2. Run `make test` and confirm all tests are passing

### Includes new or updated dependencies?
YES 

### Changes expectations for external applications?
NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/GDT-159

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes

