### PR TITLE
Set single URL for part of dct_references_s

### DIFF
--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -424,18 +424,13 @@ class SourceRecord:
                 "url": f"{cdn_root}/{cdn_folder}/{self.identifier}.zip",
             },
         ]
-        website_urls = [
-            {
-                "label": "Website",
-                "url": (
-                    "https://search.libraries.mit.edu/record/"
-                    f"gismit:{self.identifier.removeprefix('mit:')}"
-                ),
-            }
-        ]
+        website_url = (
+            "https://geodata.libraries.mit.edu/record/"
+            f"gismit:{self.identifier.removeprefix('mit:')}"
+        )
         return {
             "http://schema.org/downloadUrl": download_urls,
-            "http://schema.org/url": website_urls,
+            "http://schema.org/url": website_url,
         }
 
     def _dct_references_s_ogm(self) -> dict:

--- a/tests/test_records/test_record.py
+++ b/tests/test_records/test_record.py
@@ -175,13 +175,9 @@ def test_record_shared_field_method_dct_references_s_success(
                 "/SDE_DATA_AE_A8GNS_2003.zip",
             },
         ],
-        "http://schema.org/url": [
-            {
-                "label": "Website",
-                "url": "https://search.libraries.mit.edu/record/"
-                "gismit:SDE_DATA_AE_A8GNS_2003",
-            },
-        ],
+        "http://schema.org/url": (
+            "https://geodata.libraries.mit.edu/record/gismit:SDE_DATA_AE_A8GNS_2003"
+        ),
     }
     assert fgdc_source_record_from_zip._dct_references_s() == json.dumps(references)
 


### PR DESCRIPTION
### Purpose and background context
It was discovered that the Aardvark format expects only a single URL for the dct_references_s key `http://schema.org/url`, where previously we had set this as a list of objects containing lable and URL like `http://schemal.org/downloadUrl`.

This changes the final structure from an array of objects:
```json
{
    "http://schema.org/url":[ {complex object here...} ]
}
```
to a single string:
```json
{
    "http://schema.org/url": "https://geodata.libraries.mit.edu/record/abc123"
}
```

This also updates the hostname for where this URL points back to `geodata.libraries.mit.edu` which is the anticipated TIMDEX UI for geo resources.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES - Transmogrifier has an associated PR: https://github.com/MITLibraries/transmogrifier/pull/118

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-68

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes

