### PR TITLE
Fetch and filter records for Alma MARC harvest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pygit2 = "*"
 shapely = "*"
 requests = "*"
 pyaml = "*"
+marcalyx = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f047f16c77fe6ad020beb7dd06ed4e0de601b82fa5ce69ac26dc162689aca079"
+            "sha256": "e5ce214486aad2e12350d56f32d491ef6f53e959abeaff3f67e2aa4f47ee2c3d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:35bcbecf1b5d3620c93f0062d2994177f8bda25a9d2cba144d6462793c16065b",
-                "sha256:476896e70d36c9134d4125834280c597c17b54bff4902baf2e5fcde74f8acec8"
+                "sha256:340c73f57fcca6f503403e2e13a0a4ad44bec218feee2e0896be612324394afd",
+                "sha256:cd30261a782824ce543a628ae524480abb4ca6ab4e4a2631477e48baed43b5f2"
             ],
             "index": "pypi",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "botocore": {
             "hashes": [
-                "sha256:9f00bd5e4698bcdd37ce6e224a896baf58d209678ed92834944b767de9061cc5",
-                "sha256:e175360445424b83b0e28ae20d301b99cf44ff2c9d5ab1d8670899bec05a9753"
+                "sha256:3d243781e994dfc5b20036d9fb92672bfaef4dbe388eaa79dae6440ea56c53eb",
+                "sha256:cbbcaddc35738d32df55d26ed5561cf3fa32751a6b22e7e342be87b5e3f55eec"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "certifi": {
             "hashes": [
@@ -334,6 +334,14 @@
             "index": "pypi",
             "version": "==5.1.0"
         },
+        "marcalyx": {
+            "hashes": [
+                "sha256:226086dda558bd2c15e071de92874e42b3bb06d31bc05c93689c3ec6147f5520",
+                "sha256:fef670cc6e55ab75466d7b4198e0f2dc72746415d8101c24a10224161fc04671"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
+        },
         "numpy": {
             "hashes": [
                 "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b",
@@ -432,11 +440,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -521,108 +529,108 @@
         },
         "rpds-py": {
             "hashes": [
-                "sha256:01f58a7306b64e0a4fe042047dd2b7d411ee82e54240284bab63e325762c1147",
-                "sha256:0210b2668f24c078307260bf88bdac9d6f1093635df5123789bfee4d8d7fc8e7",
-                "sha256:02866e060219514940342a1f84303a1ef7a1dad0ac311792fbbe19b521b489d2",
-                "sha256:0387ce69ba06e43df54e43968090f3626e231e4bc9150e4c3246947567695f68",
-                "sha256:060f412230d5f19fc8c8b75f315931b408d8ebf56aec33ef4168d1b9e54200b1",
-                "sha256:071bc28c589b86bc6351a339114fb7a029f5cddbaca34103aa573eba7b482382",
-                "sha256:0bfb09bf41fe7c51413f563373e5f537eaa653d7adc4830399d4e9bdc199959d",
-                "sha256:10162fe3f5f47c37ebf6d8ff5a2368508fe22007e3077bf25b9c7d803454d921",
-                "sha256:149c5cd24f729e3567b56e1795f74577aa3126c14c11e457bec1b1c90d212e38",
-                "sha256:1701fc54460ae2e5efc1dd6350eafd7a760f516df8dbe51d4a1c79d69472fbd4",
-                "sha256:1957a2ab607f9added64478a6982742eb29f109d89d065fa44e01691a20fc20a",
-                "sha256:1a746a6d49665058a5896000e8d9d2f1a6acba8a03b389c1e4c06e11e0b7f40d",
-                "sha256:1bfcad3109c1e5ba3cbe2f421614e70439f72897515a96c462ea657261b96518",
-                "sha256:1d36b2b59e8cc6e576f8f7b671e32f2ff43153f0ad6d0201250a7c07f25d570e",
-                "sha256:1db228102ab9d1ff4c64148c96320d0be7044fa28bd865a9ce628ce98da5973d",
-                "sha256:1dc29db3900cb1bb40353772417800f29c3d078dbc8024fd64655a04ee3c4bdf",
-                "sha256:1e626b365293a2142a62b9a614e1f8e331b28f3ca57b9f05ebbf4cf2a0f0bdc5",
-                "sha256:1f3c3461ebb4c4f1bbc70b15d20b565759f97a5aaf13af811fcefc892e9197ba",
-                "sha256:20de7b7179e2031a04042e85dc463a93a82bc177eeba5ddd13ff746325558aa6",
-                "sha256:24e4900a6643f87058a27320f81336d527ccfe503984528edde4bb660c8c8d59",
-                "sha256:2528ff96d09f12e638695f3a2e0c609c7b84c6df7c5ae9bfeb9252b6fa686253",
-                "sha256:25f071737dae674ca8937a73d0f43f5a52e92c2d178330b4c0bb6ab05586ffa6",
-                "sha256:270987bc22e7e5a962b1094953ae901395e8c1e1e83ad016c5cfcfff75a15a3f",
-                "sha256:292f7344a3301802e7c25c53792fae7d1593cb0e50964e7bcdcc5cf533d634e3",
-                "sha256:2953937f83820376b5979318840f3ee47477d94c17b940fe31d9458d79ae7eea",
-                "sha256:2a792b2e1d3038daa83fa474d559acfd6dc1e3650ee93b2662ddc17dbff20ad1",
-                "sha256:2a7b2f2f56a16a6d62e55354dd329d929560442bd92e87397b7a9586a32e3e76",
-                "sha256:2f4eb548daf4836e3b2c662033bfbfc551db58d30fd8fe660314f86bf8510b93",
-                "sha256:3664d126d3388a887db44c2e293f87d500c4184ec43d5d14d2d2babdb4c64cad",
-                "sha256:3677fcca7fb728c86a78660c7fb1b07b69b281964673f486ae72860e13f512ad",
-                "sha256:380e0df2e9d5d5d339803cfc6d183a5442ad7ab3c63c2a0982e8c824566c5ccc",
-                "sha256:3ac732390d529d8469b831949c78085b034bff67f584559340008d0f6041a049",
-                "sha256:4128980a14ed805e1b91a7ed551250282a8ddf8201a4e9f8f5b7e6225f54170d",
-                "sha256:4341bd7579611cf50e7b20bb8c2e23512a3dc79de987a1f411cb458ab670eb90",
-                "sha256:436474f17733c7dca0fbf096d36ae65277e8645039df12a0fa52445ca494729d",
-                "sha256:4dc889a9d8a34758d0fcc9ac86adb97bab3fb7f0c4d29794357eb147536483fd",
-                "sha256:4e21b76075c01d65d0f0f34302b5a7457d95721d5e0667aea65e5bb3ab415c25",
-                "sha256:516fb8c77805159e97a689e2f1c80655c7658f5af601c34ffdb916605598cda2",
-                "sha256:5576ee2f3a309d2bb403ec292d5958ce03953b0e57a11d224c1f134feaf8c40f",
-                "sha256:5a024fa96d541fd7edaa0e9d904601c6445e95a729a2900c5aec6555fe921ed6",
-                "sha256:5d0e8a6434a3fbf77d11448c9c25b2f25244226cfbec1a5159947cac5b8c5fa4",
-                "sha256:5e7d63ec01fe7c76c2dbb7e972fece45acbb8836e72682bde138e7e039906e2c",
-                "sha256:60e820ee1004327609b28db8307acc27f5f2e9a0b185b2064c5f23e815f248f8",
-                "sha256:637b802f3f069a64436d432117a7e58fab414b4e27a7e81049817ae94de45d8d",
-                "sha256:65dcf105c1943cba45d19207ef51b8bc46d232a381e94dd38719d52d3980015b",
-                "sha256:698ea95a60c8b16b58be9d854c9f993c639f5c214cf9ba782eca53a8789d6b19",
-                "sha256:70fcc6c2906cfa5c6a552ba7ae2ce64b6c32f437d8f3f8eea49925b278a61453",
-                "sha256:720215373a280f78a1814becb1312d4e4d1077b1202a56d2b0815e95ccb99ce9",
-                "sha256:7450dbd659fed6dd41d1a7d47ed767e893ba402af8ae664c157c255ec6067fde",
-                "sha256:7b7d9ca34542099b4e185b3c2a2b2eda2e318a7dbde0b0d83357a6d4421b5296",
-                "sha256:7fbd70cb8b54fe745301921b0816c08b6d917593429dfc437fd024b5ba713c58",
-                "sha256:81038ff87a4e04c22e1d81f947c6ac46f122e0c80460b9006e6517c4d842a6ec",
-                "sha256:810685321f4a304b2b55577c915bece4c4a06dfe38f6e62d9cc1d6ca8ee86b99",
-                "sha256:82ada4a8ed9e82e443fcef87e22a3eed3654dd3adf6e3b3a0deb70f03e86142a",
-                "sha256:841320e1841bb53fada91c9725e766bb25009cfd4144e92298db296fb6c894fb",
-                "sha256:8587fd64c2a91c33cdc39d0cebdaf30e79491cc029a37fcd458ba863f8815383",
-                "sha256:8ffe53e1d8ef2520ebcf0c9fec15bb721da59e8ef283b6ff3079613b1e30513d",
-                "sha256:9051e3d2af8f55b42061603e29e744724cb5f65b128a491446cc029b3e2ea896",
-                "sha256:91e5a8200e65aaac342a791272c564dffcf1281abd635d304d6c4e6b495f29dc",
-                "sha256:93432e747fb07fa567ad9cc7aaadd6e29710e515aabf939dfbed8046041346c6",
-                "sha256:938eab7323a736533f015e6069a7d53ef2dcc841e4e533b782c2bfb9fb12d84b",
-                "sha256:9584f8f52010295a4a417221861df9bea4c72d9632562b6e59b3c7b87a1522b7",
-                "sha256:9737bdaa0ad33d34c0efc718741abaafce62fadae72c8b251df9b0c823c63b22",
-                "sha256:99da0a4686ada4ed0f778120a0ea8d066de1a0a92ab0d13ae68492a437db78bf",
-                "sha256:99f567dae93e10be2daaa896e07513dd4bf9c2ecf0576e0533ac36ba3b1d5394",
-                "sha256:9bdf1303df671179eaf2cb41e8515a07fc78d9d00f111eadbe3e14262f59c3d0",
-                "sha256:9f0e4dc0f17dcea4ab9d13ac5c666b6b5337042b4d8f27e01b70fae41dd65c57",
-                "sha256:a000133a90eea274a6f28adc3084643263b1e7c1a5a66eb0a0a7a36aa757ed74",
-                "sha256:a3264e3e858de4fc601741498215835ff324ff2482fd4e4af61b46512dd7fc83",
-                "sha256:a71169d505af63bb4d20d23a8fbd4c6ce272e7bce6cc31f617152aa784436f29",
-                "sha256:a967dd6afda7715d911c25a6ba1517975acd8d1092b2f326718725461a3d33f9",
-                "sha256:aa5bfb13f1e89151ade0eb812f7b0d7a4d643406caaad65ce1cbabe0a66d695f",
-                "sha256:ae35e8e6801c5ab071b992cb2da958eee76340e6926ec693b5ff7d6381441745",
-                "sha256:b686f25377f9c006acbac63f61614416a6317133ab7fafe5de5f7dc8a06d42eb",
-                "sha256:b760a56e080a826c2e5af09002c1a037382ed21d03134eb6294812dda268c811",
-                "sha256:b86b21b348f7e5485fae740d845c65a880f5d1eda1e063bc59bef92d1f7d0c55",
-                "sha256:b9412abdf0ba70faa6e2ee6c0cc62a8defb772e78860cef419865917d86c7342",
-                "sha256:bd345a13ce06e94c753dab52f8e71e5252aec1e4f8022d24d56decd31e1b9b23",
-                "sha256:be22ae34d68544df293152b7e50895ba70d2a833ad9566932d750d3625918b82",
-                "sha256:bf046179d011e6114daf12a534d874958b039342b347348a78b7cdf0dd9d6041",
-                "sha256:c3d2010656999b63e628a3c694f23020322b4178c450dc478558a2b6ef3cb9bb",
-                "sha256:c64602e8be701c6cfe42064b71c84ce62ce66ddc6422c15463fd8127db3d8066",
-                "sha256:d65e6b4f1443048eb7e833c2accb4fa7ee67cc7d54f31b4f0555b474758bee55",
-                "sha256:d8bbd8e56f3ba25a7d0cf980fc42b34028848a53a0e36c9918550e0280b9d0b6",
-                "sha256:da1ead63368c04a9bded7904757dfcae01eba0e0f9bc41d3d7f57ebf1c04015a",
-                "sha256:dbbb95e6fc91ea3102505d111b327004d1c4ce98d56a4a02e82cd451f9f57140",
-                "sha256:dbc56680ecf585a384fbd93cd42bc82668b77cb525343170a2d86dafaed2a84b",
-                "sha256:df3b6f45ba4515632c5064e35ca7f31d51d13d1479673185ba8f9fefbbed58b9",
-                "sha256:dfe07308b311a8293a0d5ef4e61411c5c20f682db6b5e73de6c7c8824272c256",
-                "sha256:e796051f2070f47230c745d0a77a91088fbee2cc0502e9b796b9c6471983718c",
-                "sha256:efa767c220d94aa4ac3a6dd3aeb986e9f229eaf5bce92d8b1b3018d06bed3772",
-                "sha256:f0b8bf5b8db49d8fd40f54772a1dcf262e8be0ad2ab0206b5a2ec109c176c0a4",
-                "sha256:f175e95a197f6a4059b50757a3dca33b32b61691bdbd22c29e8a8d21d3914cae",
-                "sha256:f2f3b28b40fddcb6c1f1f6c88c6f3769cd933fa493ceb79da45968a21dccc920",
-                "sha256:f6c43b6f97209e370124baf2bf40bb1e8edc25311a158867eb1c3a5d449ebc7a",
-                "sha256:f7f4cb1f173385e8a39c29510dd11a78bf44e360fb75610594973f5ea141028b",
-                "sha256:fad059a4bd14c45776600d223ec194e77db6c20255578bb5bcdd7c18fd169361",
-                "sha256:ff1dcb8e8bc2261a088821b2595ef031c91d499a0c1b031c152d43fe0a6ecec8",
-                "sha256:ffee088ea9b593cc6160518ba9bd319b5475e5f3e578e4552d63818773c6f56a"
+                "sha256:01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f",
+                "sha256:044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c",
+                "sha256:08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76",
+                "sha256:08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e",
+                "sha256:0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157",
+                "sha256:0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f",
+                "sha256:0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5",
+                "sha256:11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05",
+                "sha256:1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24",
+                "sha256:1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1",
+                "sha256:1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8",
+                "sha256:1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b",
+                "sha256:22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb",
+                "sha256:2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07",
+                "sha256:2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1",
+                "sha256:30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6",
+                "sha256:34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e",
+                "sha256:36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e",
+                "sha256:39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1",
+                "sha256:39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab",
+                "sha256:3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4",
+                "sha256:3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17",
+                "sha256:41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594",
+                "sha256:42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d",
+                "sha256:43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d",
+                "sha256:4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3",
+                "sha256:465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c",
+                "sha256:482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66",
+                "sha256:4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f",
+                "sha256:4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80",
+                "sha256:5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33",
+                "sha256:5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f",
+                "sha256:56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c",
+                "sha256:586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022",
+                "sha256:5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e",
+                "sha256:5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f",
+                "sha256:618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da",
+                "sha256:635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1",
+                "sha256:661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688",
+                "sha256:66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795",
+                "sha256:67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c",
+                "sha256:685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98",
+                "sha256:69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1",
+                "sha256:6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20",
+                "sha256:6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307",
+                "sha256:6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4",
+                "sha256:6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18",
+                "sha256:6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294",
+                "sha256:7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66",
+                "sha256:77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467",
+                "sha256:793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948",
+                "sha256:7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e",
+                "sha256:7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1",
+                "sha256:7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0",
+                "sha256:84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7",
+                "sha256:8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd",
+                "sha256:8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641",
+                "sha256:8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d",
+                "sha256:8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9",
+                "sha256:8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1",
+                "sha256:923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da",
+                "sha256:93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3",
+                "sha256:998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa",
+                "sha256:99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7",
+                "sha256:9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40",
+                "sha256:9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496",
+                "sha256:9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124",
+                "sha256:a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836",
+                "sha256:a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434",
+                "sha256:a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984",
+                "sha256:ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f",
+                "sha256:aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6",
+                "sha256:b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e",
+                "sha256:b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461",
+                "sha256:b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c",
+                "sha256:bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432",
+                "sha256:bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73",
+                "sha256:c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58",
+                "sha256:c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88",
+                "sha256:c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337",
+                "sha256:c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7",
+                "sha256:c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863",
+                "sha256:cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475",
+                "sha256:cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3",
+                "sha256:d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51",
+                "sha256:d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf",
+                "sha256:d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024",
+                "sha256:dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40",
+                "sha256:ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9",
+                "sha256:e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec",
+                "sha256:e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb",
+                "sha256:e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7",
+                "sha256:e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861",
+                "sha256:e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880",
+                "sha256:ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f",
+                "sha256:ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd",
+                "sha256:f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca",
+                "sha256:fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58",
+                "sha256:fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.17.1"
+            "version": "==0.18.0"
         },
         "s3transfer": {
             "hashes": [
@@ -634,58 +642,58 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:3c2b027979bb400cd65a47970e64f8cef8acda86b288a27f42a98692505086cd",
-                "sha256:73383f28311ae55602bb6cc3b013830811135ba5521e41333a6e68f269413502"
+                "sha256:becda09660df63e55f307570e9817c664392655a7328bbc414b507e9cb874c67",
+                "sha256:f143f3fb4bb57c90abef6e2ad06b5f6f02b2ca13e4060ec5c0549c7a9ccce3fa"
             ],
             "index": "pypi",
-            "version": "==1.40.3"
+            "version": "==1.40.6"
         },
         "shapely": {
             "hashes": [
-                "sha256:03e63a99dfe6bd3beb8d5f41ec2086585bb969991d603f9aeac335ad396a06d4",
-                "sha256:0521d76d1e8af01e712db71da9096b484f081e539d4f4a8c97342e7971d5e1b4",
-                "sha256:06f193091a7c6112fc08dfd195a1e3846a64306f890b151fa8c63b3e3624202c",
-                "sha256:084b023dae8ad3d5b98acee9d3bf098fdf688eb0bb9b1401e8b075f6a627b611",
-                "sha256:1713cc04c171baffc5b259ba8531c58acc2a301707b7f021d88a15ed090649e7",
-                "sha256:1f217d28ecb48e593beae20a0082a95bd9898d82d14b8fcb497edf6bff9a44d7",
-                "sha256:2d217e56ae067e87b4e1731d0dc62eebe887ced729ba5c2d4590e9e3e9fdbd88",
-                "sha256:34eac2337cbd67650248761b140d2535855d21b969d76d76123317882d3a0c1a",
-                "sha256:36480e32c434d168cdf2f5e9862c84aaf4d714a43a8465ae3ce8ff327f0affb7",
-                "sha256:394e5085b49334fd5b94fa89c086edfb39c3ecab7f669e8b2a4298b9d523b3a5",
-                "sha256:42997ac806e4583dad51c80a32d38570fd9a3d4778f5e2c98f9090aa7db0fe91",
-                "sha256:45ac6906cff0765455a7b49c1670af6e230c419507c13e2f75db638c8fc6f3bd",
-                "sha256:4ef753200cbffd4f652efb2c528c5474e5a14341a473994d90ad0606522a46a2",
-                "sha256:5324be299d4c533ecfcfd43424dfd12f9428fd6f12cda38a4316da001d6ef0ea",
-                "sha256:5b0c052709c8a257c93b0d4943b0b7a3035f87e2d6a8ac9407b6a992d206422f",
-                "sha256:6a21353d28209fb0d8cc083e08ca53c52666e0d8a1f9bbe23b6063967d89ed24",
-                "sha256:6ca8cffbe84ddde8f52b297b53f8e0687bd31141abb2c373fd8a9f032df415d6",
-                "sha256:72b5997272ae8c25f0fd5b3b967b3237e87fab7978b8d6cd5fa748770f0c5d68",
-                "sha256:737dba15011e5a9b54a8302f1748b62daa207c9bc06f820cd0ad32a041f1c6f2",
-                "sha256:78128357a0cee573257a0c2c388d4b7bf13cb7dbe5b3fe5d26d45ebbe2a39e25",
-                "sha256:794affd80ca0f2c536fc948a3afa90bd8fb61ebe37fe873483ae818e7f21def4",
-                "sha256:7e92e7c255f89f5cdf777690313311f422aa8ada9a3205b187113274e0135cd8",
-                "sha256:87dc2be34ac3a3a4a319b963c507ac06682978a5e6c93d71917618b14f13066e",
-                "sha256:94ac128ae2ab4edd0bffcd4e566411ea7bdc738aeaf92c32a8a836abad725f9f",
-                "sha256:a5533a925d8e211d07636ffc2fdd9a7f9f13d54686d00577eeb11d16f00be9c4",
-                "sha256:a9a41ff4323fc9d6257759c26eb1cf3a61ebc7e611e024e6091f42977303fd3a",
-                "sha256:b8eb0a92f7b8c74f9d8fdd1b40d395113f59bd8132ca1348ebcc1f5aece94b96",
-                "sha256:baa14fc27771e180c06b499a0a7ba697c7988c7b2b6cba9a929a19a4d2762de3",
-                "sha256:be46d5509b9251dd9087768eaf35a71360de6afac82ce87c636990a0871aa18b",
-                "sha256:c6fd29fbd9cd76350bd5cc14c49de394a31770aed02d74203e23b928f3d2f1aa",
-                "sha256:ccfd5fa10a37e67dbafc601c1ddbcbbfef70d34c3f6b0efc866ddbdb55893a6c",
-                "sha256:d41a116fcad58048d7143ddb01285e1a8780df6dc1f56c3b1e1b7f12ed296651",
-                "sha256:dc9342fc82e374130db86a955c3c4525bfbf315a248af8277a913f30911bed9e",
-                "sha256:dea9a0651333cf96ef5bb2035044e3ad6a54f87d90e50fe4c2636debf1b77abc",
-                "sha256:e7c95d3379ae3abb74058938a9fcbc478c6b2e28d20dace38f8b5c587dde90aa",
-                "sha256:e7d897e6bdc6bc64f7f65155dbbb30e49acaabbd0d9266b9b4041f87d6e52b3a",
-                "sha256:ea84d1cdbcf31e619d672b53c4532f06253894185ee7acb8ceb78f5f33cbe033",
-                "sha256:ed1e99702125e7baccf401830a3b94d810d5c70b329b765fe93451fe14cf565b",
-                "sha256:eebe544df5c018134f3c23b6515877f7e4cd72851f88a8d0c18464f414d141a2",
-                "sha256:fa3ee28f5e63a130ec5af4dc3c4cb9c21c5788bb13c15e89190d163b14f9fb89",
-                "sha256:fd3ad17b64466a033848c26cb5b509625c87d07dcf39a1541461cacdb8f7e91c"
+                "sha256:083d026e97b6c1f4a9bd2a9171c7692461092ed5375218170d91705550eecfd5",
+                "sha256:13cb37d3826972a82748a450328fe02a931dcaed10e69a4d83cc20ba021bc85f",
+                "sha256:18bddb8c327f392189a8d5d6b9a858945722d0bb95ccbd6a077b8e8fc4c7890d",
+                "sha256:27b6e1910094d93e9627f2664121e0e35613262fc037051680a08270f6058daf",
+                "sha256:300d203b480a4589adefff4c4af0b13919cd6d760ba3cbb1e56275210f96f654",
+                "sha256:31a40b6e3ab00a4fd3a1d44efb2482278642572b8e0451abdc8e0634b787173e",
+                "sha256:42bceb9bceb3710a774ce04908fda0f28b291323da2688f928b3f213373b5aee",
+                "sha256:442f4dcf1eb58c5a4e3428d88e988ae153f97ab69a9f24e07bf4af8038536325",
+                "sha256:4d279e56bbb68d218d63f3efc80c819cedcceef0e64efbf058a1df89dc57201b",
+                "sha256:4d65d0aa7910af71efa72fd6447e02a8e5dd44da81a983de9d736d6e6ccbe674",
+                "sha256:5026b30433a70911979d390009261b8c4021ff87c7c3cbd825e62bb2ffa181bc",
+                "sha256:54d925c9a311e4d109ec25f6a54a8bd92cc03481a34ae1a6a92c1fe6729b7e01",
+                "sha256:56cee3e4e8159d6f2ce32e421445b8e23154fd02a0ac271d6a6c0b266a8e3cce",
+                "sha256:58afbba12c42c6ed44c4270bc0e22f3dadff5656d711b0ad335c315e02d04707",
+                "sha256:59b16976c2473fec85ce65cc9239bef97d4205ab3acead4e6cdcc72aee535679",
+                "sha256:601c5c0058a6192df704cb889439f64994708563f57f99574798721e9777a44b",
+                "sha256:619232c8276fded09527d2a9fd91a7885ff95c0ff9ecd5e3cb1e34fbb676e2ae",
+                "sha256:64c5013dacd2d81b3bb12672098a0b2795c1bf8190cfc2980e380f5ef9d9e4d9",
+                "sha256:6b464f2666b13902835f201f50e835f2f153f37741db88f68c7f3b932d3505fa",
+                "sha256:6dfdc077a6fcaf74d3eab23a1ace5abc50c8bce56ac7747d25eab582c5a2990e",
+                "sha256:6f555fe3304a1f40398977789bc4fe3c28a11173196df9ece1e15c5bc75a48db",
+                "sha256:705efbce1950a31a55b1daa9c6ae1c34f1296de71ca8427974ec2f27d57554e3",
+                "sha256:71b2de56a9e8c0e5920ae5ddb23b923490557ac50cb0b7fa752761bf4851acde",
+                "sha256:71eb736ef2843f23473c6e37f6180f90f0a35d740ab284321548edf4e55d9a52",
+                "sha256:881eb9dbbb4a6419667e91fcb20313bfc1e67f53dbb392c6840ff04793571ed1",
+                "sha256:882fb1ffc7577e88c1194f4f1757e277dc484ba096a3b94844319873d14b0f2d",
+                "sha256:88566d01a30f0453f7d038db46bc83ce125e38e47c5f6bfd4c9c287010e9bf74",
+                "sha256:9302d7011e3e376d25acd30d2d9e70d315d93f03cc748784af19b00988fc30b1",
+                "sha256:98040462b36ced9671e266b95c326b97f41290d9d17504a1ee4dc313a7667b9c",
+                "sha256:99abad1fd1303b35d991703432c9481e3242b7b3a393c186cfb02373bf604004",
+                "sha256:a983cc418c1fa160b7d797cfef0e0c9f8c6d5871e83eae2c5793fce6a837fad9",
+                "sha256:af7e9abe180b189431b0f490638281b43b84a33a960620e6b2e8d3e3458b61a1",
+                "sha256:b2a7d256db6f5b4b407dc0c98dd1b2fcf1c9c5814af9416e5498d0a2e4307a4b",
+                "sha256:b9f2d93bff2ea52fa93245798cddb479766a18510ea9b93a4fb9755c79474889",
+                "sha256:bd45d456983dc60a42c4db437496d3f08a4201fbf662b69779f535eb969660af",
+                "sha256:c91981c99ade980fc49e41a544629751a0ccd769f39794ae913e53b07b2f78b9",
+                "sha256:d8c2a2989222c6062f7a0656e16276c01bb308bc7e5d999e54bf4e294ce62e76",
+                "sha256:e45f0c8cd4583647db3216d965d49363e6548c300c23fd7e57ce17a03f824034",
+                "sha256:e86e7cb8e331a4850e0c2a8b2d66dc08d7a7b301b8d1d34a13060e3a5b4b3b55",
+                "sha256:f10d2ccf0554fc0e39fad5886c839e47e207f99fdf09547bc687a2330efda35b",
+                "sha256:f24ecbb90a45c962b3b60d8d9a387272ed50dc010bfe605f1d16dfc94772d8a1"
             ],
             "index": "pypi",
-            "version": "==2.0.2"
+            "version": "==2.0.3"
         },
         "six": {
             "hashes": [
@@ -697,11 +705,11 @@
         },
         "smart-open": {
             "hashes": [
-                "sha256:8d3ef7e6997e8e42dd55c74166ed21e6ac70664caa32dd940b26d54a8f6b4142",
-                "sha256:be3c92c246fbe80ebce8fbacb180494a481a77fcdcb7c1aadb2ea5b9c2bee8b9"
+                "sha256:9507e38b43d1fd515c2085b9db2e41b592bb754b0e31395a085eb0d61d2410e5",
+                "sha256:c03d00e49483d8e5375720d4d6c1402107f23584bf96505db0b4e17f92339e56"
             ],
             "index": "pypi",
-            "version": "==6.4.0"
+            "version": "==7.0.1"
         },
         "urllib3": {
             "hashes": [
@@ -710,6 +718,82 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.7"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc",
+                "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81",
+                "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09",
+                "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e",
+                "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca",
+                "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0",
+                "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb",
+                "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487",
+                "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40",
+                "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c",
+                "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060",
+                "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202",
+                "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41",
+                "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9",
+                "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b",
+                "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664",
+                "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d",
+                "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362",
+                "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00",
+                "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc",
+                "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1",
+                "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267",
+                "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956",
+                "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966",
+                "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1",
+                "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228",
+                "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72",
+                "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d",
+                "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292",
+                "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0",
+                "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0",
+                "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36",
+                "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c",
+                "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5",
+                "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f",
+                "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73",
+                "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b",
+                "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2",
+                "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593",
+                "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39",
+                "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389",
+                "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf",
+                "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf",
+                "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89",
+                "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c",
+                "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c",
+                "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f",
+                "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440",
+                "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465",
+                "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136",
+                "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b",
+                "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8",
+                "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3",
+                "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8",
+                "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6",
+                "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e",
+                "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f",
+                "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c",
+                "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e",
+                "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8",
+                "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2",
+                "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020",
+                "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35",
+                "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d",
+                "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3",
+                "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537",
+                "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809",
+                "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d",
+                "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
+                "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.16.0"
         }
     },
     "develop": {
@@ -730,39 +814,39 @@
         },
         "black": {
             "hashes": [
-                "sha256:0269dfdea12442022e88043d2910429bed717b2d04523867a85dacce535916b8",
-                "sha256:07204d078e25327aad9ed2c64790d681238686bce254c910de640c7cc4fc3aa6",
-                "sha256:08b34e85170d368c37ca7bf81cf67ac863c9d1963b2c1780c39102187ec8dd62",
-                "sha256:1a95915c98d6e32ca43809d46d932e2abc5f1f7d582ffbe65a5b4d1588af7445",
-                "sha256:2588021038bd5ada078de606f2a804cadd0a3cc6a79cb3e9bb3a8bf581325a4c",
-                "sha256:2fa6a0e965779c8f2afb286f9ef798df770ba2b6cee063c650b96adec22c056a",
-                "sha256:34afe9da5056aa123b8bfda1664bfe6fb4e9c6f311d8e4a6eb089da9a9173bf9",
-                "sha256:3897ae5a21ca132efa219c029cce5e6bfc9c3d34ed7e892113d199c0b1b444a2",
-                "sha256:40657e1b78212d582a0edecafef133cf1dd02e6677f539b669db4746150d38f6",
-                "sha256:48b5760dcbfe5cf97fd4fba23946681f3a81514c6ab8a45b50da67ac8fbc6c7b",
-                "sha256:5242ecd9e990aeb995b6d03dc3b2d112d4a78f2083e5a8e86d566340ae80fec4",
-                "sha256:5cdc2e2195212208fbcae579b931407c1fa9997584f0a415421748aeafff1168",
-                "sha256:5d7b06ea8816cbd4becfe5f70accae953c53c0e53aa98730ceccb0395520ee5d",
-                "sha256:7258c27115c1e3b5de9ac6c4f9957e3ee2c02c0b39222a24dc7aa03ba0e986f5",
-                "sha256:854c06fb86fd854140f37fb24dbf10621f5dab9e3b0c29a690ba595e3d543024",
-                "sha256:a21725862d0e855ae05da1dd25e3825ed712eaaccef6b03017fe0853a01aa45e",
-                "sha256:a83fe522d9698d8f9a101b860b1ee154c1d25f8a82ceb807d319f085b2627c5b",
-                "sha256:b3d64db762eae4a5ce04b6e3dd745dcca0fb9560eb931a5be97472e38652a161",
-                "sha256:e298d588744efda02379521a19639ebcd314fba7a49be22136204d7ed1782717",
-                "sha256:e2c8dfa14677f90d976f68e0c923947ae68fa3961d61ee30976c388adc0b02c8",
-                "sha256:ecba2a15dfb2d97105be74bbfe5128bc5e9fa8477d8c46766505c1dda5883aac",
-                "sha256:fc1ec9aa6f4d98d022101e015261c056ddebe3da6a8ccfc2c792cbe0349d48b7"
+                "sha256:057c3dc602eaa6fdc451069bd027a1b2635028b575a6c3acfd63193ced20d9c8",
+                "sha256:08654d0797e65f2423f850fc8e16a0ce50925f9337fb4a4a176a7aa4026e63f8",
+                "sha256:163baf4ef40e6897a2a9b83890e59141cc8c2a98f2dda5080dc15c00ee1e62cd",
+                "sha256:1e08fb9a15c914b81dd734ddd7fb10513016e5ce7e6704bdd5e1251ceee51ac9",
+                "sha256:4dd76e9468d5536abd40ffbc7a247f83b2324f0c050556d9c371c2b9a9a95e31",
+                "sha256:4f9de21bafcba9683853f6c96c2d515e364aee631b178eaa5145fc1c61a3cc92",
+                "sha256:61a0391772490ddfb8a693c067df1ef5227257e72b0e4108482b8d41b5aee13f",
+                "sha256:6981eae48b3b33399c8757036c7f5d48a535b962a7c2310d19361edeef64ce29",
+                "sha256:7e53a8c630f71db01b28cd9602a1ada68c937cbf2c333e6ed041390d6968faf4",
+                "sha256:810d445ae6069ce64030c78ff6127cd9cd178a9ac3361435708b907d8a04c693",
+                "sha256:93601c2deb321b4bad8f95df408e3fb3943d85012dddb6121336b8e24a0d1218",
+                "sha256:992e451b04667116680cb88f63449267c13e1ad134f30087dec8527242e9862a",
+                "sha256:9db528bccb9e8e20c08e716b3b09c6bdd64da0dd129b11e160bf082d4642ac23",
+                "sha256:a0057f800de6acc4407fe75bb147b0c2b5cbb7c3ed110d3e5999cd01184d53b0",
+                "sha256:ba15742a13de85e9b8f3239c8f807723991fbfae24bad92d34a2b12e81904982",
+                "sha256:bce4f25c27c3435e4dace4815bcb2008b87e167e3bf4ee47ccdc5ce906eb4894",
+                "sha256:ca610d29415ee1a30a3f30fab7a8f4144e9d34c89a235d81292a1edb2b55f540",
+                "sha256:d533d5e3259720fdbc1b37444491b024003e012c5173f7d06825a77508085430",
+                "sha256:d84f29eb3ee44859052073b7636533ec995bd0f64e2fb43aeceefc70090e752b",
+                "sha256:e37c99f89929af50ffaf912454b3e3b47fd64109659026b678c091a4cd450fb2",
+                "sha256:e8a6ae970537e67830776488bca52000eaa37fa63b9988e8c487458d9cd5ace6",
+                "sha256:faf2ee02e6612577ba0181f4347bcbcf591eb122f7841ae5ba233d12c39dcb4d"
             ],
             "index": "pypi",
-            "version": "==24.1.1"
+            "version": "==24.2.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:35bcbecf1b5d3620c93f0062d2994177f8bda25a9d2cba144d6462793c16065b",
-                "sha256:476896e70d36c9134d4125834280c597c17b54bff4902baf2e5fcde74f8acec8"
+                "sha256:340c73f57fcca6f503403e2e13a0a4ad44bec218feee2e0896be612324394afd",
+                "sha256:cd30261a782824ce543a628ae524480abb4ca6ab4e4a2631477e48baed43b5f2"
             ],
             "index": "pypi",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "boto3-stubs": {
             "extras": [
@@ -771,27 +855,27 @@
                 "sqs"
             ],
             "hashes": [
-                "sha256:7bb2f187f93fac404b92ce59653cc720596075f7c7ac07d80883316d5dec54e1",
-                "sha256:cb00a61b389dde855a26596297cc66f7d6a18075298bb8b203818b3963b1d153"
+                "sha256:a30a23f60ab2ebbe03661c8a2b6928a35c936a790cf3624de717d3ce770baae5",
+                "sha256:ff319b348fa7b0d6e40f685378297266f939038c06d04e0918aa5acf2e532c2c"
             ],
             "index": "pypi",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "botocore": {
             "hashes": [
-                "sha256:9f00bd5e4698bcdd37ce6e224a896baf58d209678ed92834944b767de9061cc5",
-                "sha256:e175360445424b83b0e28ae20d301b99cf44ff2c9d5ab1d8670899bec05a9753"
+                "sha256:3d243781e994dfc5b20036d9fb92672bfaef4dbe388eaa79dae6440ea56c53eb",
+                "sha256:cbbcaddc35738d32df55d26ed5561cf3fa32751a6b22e7e342be87b5e3f55eec"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:2caf0a0d547ded49306408ea959d94aba39dd960b7de119d906c2829d149ece6",
-                "sha256:f1d689abbaaf4ba50aa5534417ee0be3513acab785b8f8fbd1107639ae2c0ae5"
+                "sha256:2388bbae9ca4437fbc085cb9b8447242a097b30d6b626f8c3e5222c3c101bf2c",
+                "sha256:e357e67b64a9c6d7de10e766cd2c66589264257446dba6e5ee1c2dfcbb63be5c"
             ],
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==1.34.39"
+            "version": "==1.34.53"
         },
         "certifi": {
             "hashes": [
@@ -1037,41 +1121,41 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:087887e55e0b9c8724cf05361357875adb5c20dec27e5816b653492980d20380",
-                "sha256:09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589",
-                "sha256:130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea",
-                "sha256:141e2aa5ba100d3788c0ad7919b288f89d1fe015878b9659b307c9ef867d3a65",
-                "sha256:28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a",
-                "sha256:2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3",
-                "sha256:320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008",
-                "sha256:36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1",
-                "sha256:3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2",
-                "sha256:3dbd37e14ce795b4af61b89b037d4bc157f2cb23e676fa16932185a04dfbf635",
-                "sha256:4383b47f45b14459cab66048d384614019965ba6c1a1a141f11b5a551cace1b2",
-                "sha256:44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90",
-                "sha256:4b063d3413f853e056161eb0c7724822a9740ad3caa24b8424d776cebf98e7ee",
-                "sha256:52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a",
-                "sha256:55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242",
-                "sha256:5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12",
-                "sha256:5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2",
-                "sha256:61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d",
-                "sha256:701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be",
-                "sha256:841ec8af7a8491ac76ec5a9522226e287187a3107e12b7d686ad354bb78facee",
-                "sha256:8a06641fb07d4e8f6c7dda4fc3f8871d327803ab6542e33831c7ccfdcb4d0ad6",
-                "sha256:8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529",
-                "sha256:a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929",
-                "sha256:a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1",
-                "sha256:a7ef8dd0bf2e1d0a27042b231a3baac6883cdd5557036f5e8df7139255feaac6",
-                "sha256:ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a",
-                "sha256:b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446",
-                "sha256:b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9",
-                "sha256:e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888",
-                "sha256:ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4",
-                "sha256:fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33",
-                "sha256:fbeb725c9dc799a574518109336acccaf1303c30d45c075c665c0793c2f79a7f"
+                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
+                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
+                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
+                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
+                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
+                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
+                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
+                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
+                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
+                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
+                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
+                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
+                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
+                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
+                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
+                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
+                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
+                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
+                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
+                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
+                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
+                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
+                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
+                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
+                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
+                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
+                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
+                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
+                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
+                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
+                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
+                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.2"
+            "version": "==42.0.5"
         },
         "decorator": {
             "hashes": [
@@ -1120,11 +1204,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:a4316013779e433d08b96e5eabb7f641e6c7942e4ab5d4c509ebd2e7a8994aed",
-                "sha256:ee17bc9d499899bc9eaec1ac7bf2dc9eedd480db9d88b96d123d3b64a9d34f5d"
+                "sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791",
+                "sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.5.34"
+            "version": "==2.5.35"
         },
         "idna": {
             "hashes": [
@@ -1144,11 +1228,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:1050a3ab8473488d7eee163796b02e511d0735cf43a04ba2a8348bd0f2eaf8a5",
-                "sha256:48fbc236fbe0e138b88773fa0437751f14c3645fb483f1d4c5dee58b37e5ce73"
+                "sha256:39c6f9efc079fb19bfb0f17eee903978fe9a290b1b82d68196c641cecb76ea22",
+                "sha256:869335e8cded62ffb6fac8928e5287a05433d6462e3ebaac25f4216474dd6bc4"
             ],
             "index": "pypi",
-            "version": "==8.21.0"
+            "version": "==8.22.1"
         },
         "jedi": {
             "hashes": [
@@ -1258,11 +1342,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:62b9798aef9028432194cebb7a671f4064257bb3be662d9c1b83b94411b694bb",
-                "sha256:94e3b07a403cc8078ffee94bf404ef677112d036a57ddb5e0f19c5fcf48987f5"
+                "sha256:71bb832a18b64f10fc4cec117b9b0e2305e5831d9a17eb74f6b9819ed7613843",
+                "sha256:7e27395e5c63ff9554ae14b5baa41bfe6d6b1be0e59eb02977c6ce28411246de"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
+            "version": "==5.0.2"
         },
         "mypy": {
             "hashes": [
@@ -1363,7 +1447,7 @@
                 "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523",
                 "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"
             ],
-            "markers": "sys_platform != 'win32'",
+            "markers": "sys_platform != 'win32' and sys_platform != 'emscripten'",
             "version": "==4.9.0"
         },
         "platformdirs": {
@@ -1384,11 +1468,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:9fe989afcf095d2c4796ce7c553cf28d4d4a9b9346de3cda079bcf40748454a4",
-                "sha256:c90961d8aa706f75d60935aba09469a6b0bcb8345f127c3fbee4bdc5f114cf4b"
+                "sha256:ba637c2d7a670c10daedc059f5c49b5bd0aadbccfcd7ec15592cf9665117532c",
+                "sha256:c3ef34f463045c88658c5b99f38c1e297abdcc0ff13f98d3370055fbbfabc67e"
             ],
             "index": "pypi",
-            "version": "==3.6.1"
+            "version": "==3.6.2"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -1429,19 +1513,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c",
-                "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"
+                "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd",
+                "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"
             ],
             "index": "pypi",
-            "version": "==8.0.0"
+            "version": "==8.0.2"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -1518,139 +1602,139 @@
         },
         "responses": {
             "hashes": [
-                "sha256:a2b43f4c08bfb9c9bd242568328c65a34b318741d3fab884ac843c5ceeb543f9",
-                "sha256:b127c6ca3f8df0eb9cc82fd93109a3007a86acb24871834c47b77765152ecf8c"
+                "sha256:01ae6a02b4f34e39bffceb0fc6786b67a25eae919c6368d05eabc8d9576c2a66",
+                "sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.24.1"
+            "version": "==0.25.0"
         },
         "rpds-py": {
             "hashes": [
-                "sha256:01f58a7306b64e0a4fe042047dd2b7d411ee82e54240284bab63e325762c1147",
-                "sha256:0210b2668f24c078307260bf88bdac9d6f1093635df5123789bfee4d8d7fc8e7",
-                "sha256:02866e060219514940342a1f84303a1ef7a1dad0ac311792fbbe19b521b489d2",
-                "sha256:0387ce69ba06e43df54e43968090f3626e231e4bc9150e4c3246947567695f68",
-                "sha256:060f412230d5f19fc8c8b75f315931b408d8ebf56aec33ef4168d1b9e54200b1",
-                "sha256:071bc28c589b86bc6351a339114fb7a029f5cddbaca34103aa573eba7b482382",
-                "sha256:0bfb09bf41fe7c51413f563373e5f537eaa653d7adc4830399d4e9bdc199959d",
-                "sha256:10162fe3f5f47c37ebf6d8ff5a2368508fe22007e3077bf25b9c7d803454d921",
-                "sha256:149c5cd24f729e3567b56e1795f74577aa3126c14c11e457bec1b1c90d212e38",
-                "sha256:1701fc54460ae2e5efc1dd6350eafd7a760f516df8dbe51d4a1c79d69472fbd4",
-                "sha256:1957a2ab607f9added64478a6982742eb29f109d89d065fa44e01691a20fc20a",
-                "sha256:1a746a6d49665058a5896000e8d9d2f1a6acba8a03b389c1e4c06e11e0b7f40d",
-                "sha256:1bfcad3109c1e5ba3cbe2f421614e70439f72897515a96c462ea657261b96518",
-                "sha256:1d36b2b59e8cc6e576f8f7b671e32f2ff43153f0ad6d0201250a7c07f25d570e",
-                "sha256:1db228102ab9d1ff4c64148c96320d0be7044fa28bd865a9ce628ce98da5973d",
-                "sha256:1dc29db3900cb1bb40353772417800f29c3d078dbc8024fd64655a04ee3c4bdf",
-                "sha256:1e626b365293a2142a62b9a614e1f8e331b28f3ca57b9f05ebbf4cf2a0f0bdc5",
-                "sha256:1f3c3461ebb4c4f1bbc70b15d20b565759f97a5aaf13af811fcefc892e9197ba",
-                "sha256:20de7b7179e2031a04042e85dc463a93a82bc177eeba5ddd13ff746325558aa6",
-                "sha256:24e4900a6643f87058a27320f81336d527ccfe503984528edde4bb660c8c8d59",
-                "sha256:2528ff96d09f12e638695f3a2e0c609c7b84c6df7c5ae9bfeb9252b6fa686253",
-                "sha256:25f071737dae674ca8937a73d0f43f5a52e92c2d178330b4c0bb6ab05586ffa6",
-                "sha256:270987bc22e7e5a962b1094953ae901395e8c1e1e83ad016c5cfcfff75a15a3f",
-                "sha256:292f7344a3301802e7c25c53792fae7d1593cb0e50964e7bcdcc5cf533d634e3",
-                "sha256:2953937f83820376b5979318840f3ee47477d94c17b940fe31d9458d79ae7eea",
-                "sha256:2a792b2e1d3038daa83fa474d559acfd6dc1e3650ee93b2662ddc17dbff20ad1",
-                "sha256:2a7b2f2f56a16a6d62e55354dd329d929560442bd92e87397b7a9586a32e3e76",
-                "sha256:2f4eb548daf4836e3b2c662033bfbfc551db58d30fd8fe660314f86bf8510b93",
-                "sha256:3664d126d3388a887db44c2e293f87d500c4184ec43d5d14d2d2babdb4c64cad",
-                "sha256:3677fcca7fb728c86a78660c7fb1b07b69b281964673f486ae72860e13f512ad",
-                "sha256:380e0df2e9d5d5d339803cfc6d183a5442ad7ab3c63c2a0982e8c824566c5ccc",
-                "sha256:3ac732390d529d8469b831949c78085b034bff67f584559340008d0f6041a049",
-                "sha256:4128980a14ed805e1b91a7ed551250282a8ddf8201a4e9f8f5b7e6225f54170d",
-                "sha256:4341bd7579611cf50e7b20bb8c2e23512a3dc79de987a1f411cb458ab670eb90",
-                "sha256:436474f17733c7dca0fbf096d36ae65277e8645039df12a0fa52445ca494729d",
-                "sha256:4dc889a9d8a34758d0fcc9ac86adb97bab3fb7f0c4d29794357eb147536483fd",
-                "sha256:4e21b76075c01d65d0f0f34302b5a7457d95721d5e0667aea65e5bb3ab415c25",
-                "sha256:516fb8c77805159e97a689e2f1c80655c7658f5af601c34ffdb916605598cda2",
-                "sha256:5576ee2f3a309d2bb403ec292d5958ce03953b0e57a11d224c1f134feaf8c40f",
-                "sha256:5a024fa96d541fd7edaa0e9d904601c6445e95a729a2900c5aec6555fe921ed6",
-                "sha256:5d0e8a6434a3fbf77d11448c9c25b2f25244226cfbec1a5159947cac5b8c5fa4",
-                "sha256:5e7d63ec01fe7c76c2dbb7e972fece45acbb8836e72682bde138e7e039906e2c",
-                "sha256:60e820ee1004327609b28db8307acc27f5f2e9a0b185b2064c5f23e815f248f8",
-                "sha256:637b802f3f069a64436d432117a7e58fab414b4e27a7e81049817ae94de45d8d",
-                "sha256:65dcf105c1943cba45d19207ef51b8bc46d232a381e94dd38719d52d3980015b",
-                "sha256:698ea95a60c8b16b58be9d854c9f993c639f5c214cf9ba782eca53a8789d6b19",
-                "sha256:70fcc6c2906cfa5c6a552ba7ae2ce64b6c32f437d8f3f8eea49925b278a61453",
-                "sha256:720215373a280f78a1814becb1312d4e4d1077b1202a56d2b0815e95ccb99ce9",
-                "sha256:7450dbd659fed6dd41d1a7d47ed767e893ba402af8ae664c157c255ec6067fde",
-                "sha256:7b7d9ca34542099b4e185b3c2a2b2eda2e318a7dbde0b0d83357a6d4421b5296",
-                "sha256:7fbd70cb8b54fe745301921b0816c08b6d917593429dfc437fd024b5ba713c58",
-                "sha256:81038ff87a4e04c22e1d81f947c6ac46f122e0c80460b9006e6517c4d842a6ec",
-                "sha256:810685321f4a304b2b55577c915bece4c4a06dfe38f6e62d9cc1d6ca8ee86b99",
-                "sha256:82ada4a8ed9e82e443fcef87e22a3eed3654dd3adf6e3b3a0deb70f03e86142a",
-                "sha256:841320e1841bb53fada91c9725e766bb25009cfd4144e92298db296fb6c894fb",
-                "sha256:8587fd64c2a91c33cdc39d0cebdaf30e79491cc029a37fcd458ba863f8815383",
-                "sha256:8ffe53e1d8ef2520ebcf0c9fec15bb721da59e8ef283b6ff3079613b1e30513d",
-                "sha256:9051e3d2af8f55b42061603e29e744724cb5f65b128a491446cc029b3e2ea896",
-                "sha256:91e5a8200e65aaac342a791272c564dffcf1281abd635d304d6c4e6b495f29dc",
-                "sha256:93432e747fb07fa567ad9cc7aaadd6e29710e515aabf939dfbed8046041346c6",
-                "sha256:938eab7323a736533f015e6069a7d53ef2dcc841e4e533b782c2bfb9fb12d84b",
-                "sha256:9584f8f52010295a4a417221861df9bea4c72d9632562b6e59b3c7b87a1522b7",
-                "sha256:9737bdaa0ad33d34c0efc718741abaafce62fadae72c8b251df9b0c823c63b22",
-                "sha256:99da0a4686ada4ed0f778120a0ea8d066de1a0a92ab0d13ae68492a437db78bf",
-                "sha256:99f567dae93e10be2daaa896e07513dd4bf9c2ecf0576e0533ac36ba3b1d5394",
-                "sha256:9bdf1303df671179eaf2cb41e8515a07fc78d9d00f111eadbe3e14262f59c3d0",
-                "sha256:9f0e4dc0f17dcea4ab9d13ac5c666b6b5337042b4d8f27e01b70fae41dd65c57",
-                "sha256:a000133a90eea274a6f28adc3084643263b1e7c1a5a66eb0a0a7a36aa757ed74",
-                "sha256:a3264e3e858de4fc601741498215835ff324ff2482fd4e4af61b46512dd7fc83",
-                "sha256:a71169d505af63bb4d20d23a8fbd4c6ce272e7bce6cc31f617152aa784436f29",
-                "sha256:a967dd6afda7715d911c25a6ba1517975acd8d1092b2f326718725461a3d33f9",
-                "sha256:aa5bfb13f1e89151ade0eb812f7b0d7a4d643406caaad65ce1cbabe0a66d695f",
-                "sha256:ae35e8e6801c5ab071b992cb2da958eee76340e6926ec693b5ff7d6381441745",
-                "sha256:b686f25377f9c006acbac63f61614416a6317133ab7fafe5de5f7dc8a06d42eb",
-                "sha256:b760a56e080a826c2e5af09002c1a037382ed21d03134eb6294812dda268c811",
-                "sha256:b86b21b348f7e5485fae740d845c65a880f5d1eda1e063bc59bef92d1f7d0c55",
-                "sha256:b9412abdf0ba70faa6e2ee6c0cc62a8defb772e78860cef419865917d86c7342",
-                "sha256:bd345a13ce06e94c753dab52f8e71e5252aec1e4f8022d24d56decd31e1b9b23",
-                "sha256:be22ae34d68544df293152b7e50895ba70d2a833ad9566932d750d3625918b82",
-                "sha256:bf046179d011e6114daf12a534d874958b039342b347348a78b7cdf0dd9d6041",
-                "sha256:c3d2010656999b63e628a3c694f23020322b4178c450dc478558a2b6ef3cb9bb",
-                "sha256:c64602e8be701c6cfe42064b71c84ce62ce66ddc6422c15463fd8127db3d8066",
-                "sha256:d65e6b4f1443048eb7e833c2accb4fa7ee67cc7d54f31b4f0555b474758bee55",
-                "sha256:d8bbd8e56f3ba25a7d0cf980fc42b34028848a53a0e36c9918550e0280b9d0b6",
-                "sha256:da1ead63368c04a9bded7904757dfcae01eba0e0f9bc41d3d7f57ebf1c04015a",
-                "sha256:dbbb95e6fc91ea3102505d111b327004d1c4ce98d56a4a02e82cd451f9f57140",
-                "sha256:dbc56680ecf585a384fbd93cd42bc82668b77cb525343170a2d86dafaed2a84b",
-                "sha256:df3b6f45ba4515632c5064e35ca7f31d51d13d1479673185ba8f9fefbbed58b9",
-                "sha256:dfe07308b311a8293a0d5ef4e61411c5c20f682db6b5e73de6c7c8824272c256",
-                "sha256:e796051f2070f47230c745d0a77a91088fbee2cc0502e9b796b9c6471983718c",
-                "sha256:efa767c220d94aa4ac3a6dd3aeb986e9f229eaf5bce92d8b1b3018d06bed3772",
-                "sha256:f0b8bf5b8db49d8fd40f54772a1dcf262e8be0ad2ab0206b5a2ec109c176c0a4",
-                "sha256:f175e95a197f6a4059b50757a3dca33b32b61691bdbd22c29e8a8d21d3914cae",
-                "sha256:f2f3b28b40fddcb6c1f1f6c88c6f3769cd933fa493ceb79da45968a21dccc920",
-                "sha256:f6c43b6f97209e370124baf2bf40bb1e8edc25311a158867eb1c3a5d449ebc7a",
-                "sha256:f7f4cb1f173385e8a39c29510dd11a78bf44e360fb75610594973f5ea141028b",
-                "sha256:fad059a4bd14c45776600d223ec194e77db6c20255578bb5bcdd7c18fd169361",
-                "sha256:ff1dcb8e8bc2261a088821b2595ef031c91d499a0c1b031c152d43fe0a6ecec8",
-                "sha256:ffee088ea9b593cc6160518ba9bd319b5475e5f3e578e4552d63818773c6f56a"
+                "sha256:01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f",
+                "sha256:044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c",
+                "sha256:08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76",
+                "sha256:08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e",
+                "sha256:0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157",
+                "sha256:0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f",
+                "sha256:0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5",
+                "sha256:11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05",
+                "sha256:1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24",
+                "sha256:1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1",
+                "sha256:1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8",
+                "sha256:1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b",
+                "sha256:22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb",
+                "sha256:2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07",
+                "sha256:2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1",
+                "sha256:30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6",
+                "sha256:34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e",
+                "sha256:36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e",
+                "sha256:39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1",
+                "sha256:39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab",
+                "sha256:3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4",
+                "sha256:3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17",
+                "sha256:41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594",
+                "sha256:42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d",
+                "sha256:43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d",
+                "sha256:4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3",
+                "sha256:465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c",
+                "sha256:482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66",
+                "sha256:4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f",
+                "sha256:4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80",
+                "sha256:5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33",
+                "sha256:5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f",
+                "sha256:56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c",
+                "sha256:586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022",
+                "sha256:5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e",
+                "sha256:5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f",
+                "sha256:618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da",
+                "sha256:635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1",
+                "sha256:661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688",
+                "sha256:66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795",
+                "sha256:67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c",
+                "sha256:685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98",
+                "sha256:69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1",
+                "sha256:6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20",
+                "sha256:6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307",
+                "sha256:6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4",
+                "sha256:6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18",
+                "sha256:6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294",
+                "sha256:7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66",
+                "sha256:77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467",
+                "sha256:793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948",
+                "sha256:7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e",
+                "sha256:7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1",
+                "sha256:7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0",
+                "sha256:84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7",
+                "sha256:8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd",
+                "sha256:8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641",
+                "sha256:8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d",
+                "sha256:8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9",
+                "sha256:8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1",
+                "sha256:923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da",
+                "sha256:93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3",
+                "sha256:998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa",
+                "sha256:99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7",
+                "sha256:9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40",
+                "sha256:9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496",
+                "sha256:9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124",
+                "sha256:a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836",
+                "sha256:a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434",
+                "sha256:a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984",
+                "sha256:ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f",
+                "sha256:aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6",
+                "sha256:b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e",
+                "sha256:b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461",
+                "sha256:b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c",
+                "sha256:bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432",
+                "sha256:bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73",
+                "sha256:c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58",
+                "sha256:c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88",
+                "sha256:c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337",
+                "sha256:c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7",
+                "sha256:c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863",
+                "sha256:cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475",
+                "sha256:cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3",
+                "sha256:d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51",
+                "sha256:d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf",
+                "sha256:d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024",
+                "sha256:dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40",
+                "sha256:ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9",
+                "sha256:e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec",
+                "sha256:e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb",
+                "sha256:e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7",
+                "sha256:e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861",
+                "sha256:e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880",
+                "sha256:ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f",
+                "sha256:ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd",
+                "sha256:f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca",
+                "sha256:fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58",
+                "sha256:fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.17.1"
+            "version": "==0.18.0"
         },
         "ruff": {
             "hashes": [
-                "sha256:0034d5b6323e6e8fe91b2a1e55b02d92d0b582d2953a2b37a67a2d7dedbb7acc",
-                "sha256:00a818e2db63659570403e44383ab03c529c2b9678ba4ba6c105af7854008105",
-                "sha256:0a725823cb2a3f08ee743a534cb6935727d9e47409e4ad72c10a3faf042ad5ba",
-                "sha256:13471684694d41ae0f1e8e3a7497e14cd57ccb7dd72ae08d56a159d6c9c3e30e",
-                "sha256:3b42b5d8677cd0c72b99fcaf068ffc62abb5a19e71b4a3b9cfa50658a0af02f1",
-                "sha256:6b95ac9ce49b4fb390634d46d6ece32ace3acdd52814671ccaf20b7f60adb232",
-                "sha256:7022d66366d6fded4ba3889f73cd791c2d5621b2ccf34befc752cb0df70f5fad",
-                "sha256:a11567e20ea39d1f51aebd778685582d4c56ccb082c1161ffc10f79bebe6df35",
-                "sha256:be60592f9d218b52f03384d1325efa9d3b41e4c4d55ea022cd548547cc42cd2b",
-                "sha256:c92db7101ef5bfc18e96777ed7bc7c822d545fa5977e90a585accac43d22f18a",
-                "sha256:dc586724a95b7d980aa17f671e173df00f0a2eef23f8babbeee663229a938fec",
-                "sha256:dd81b911d28925e7e8b323e8d06951554655021df8dd4ac3045d7212ac4ba080",
-                "sha256:e3affdcbc2afb6f5bd0eb3130139ceedc5e3f28d206fe49f63073cb9e65988e0",
-                "sha256:e5cb5526d69bb9143c2e4d2a115d08ffca3d8e0fddc84925a7b54931c96f5c02",
-                "sha256:efababa8e12330aa94a53e90a81eb6e2d55f348bc2e71adbf17d9cad23c03ee6",
-                "sha256:f3ef052283da7dec1987bba8d8733051c2325654641dfe5877a4022108098683",
-                "sha256:fbd2288890b88e8aab4499e55148805b58ec711053588cc2f0196a44f6e3d855"
+                "sha256:0886184ba2618d815067cf43e005388967b67ab9c80df52b32ec1152ab49f53a",
+                "sha256:128265876c1d703e5f5e5a4543bd8be47c73a9ba223fd3989d4aa87dd06f312f",
+                "sha256:19eacceb4c9406f6c41af806418a26fdb23120dfe53583df76d1401c92b7c14b",
+                "sha256:23dbb808e2f1d68eeadd5f655485e235c102ac6f12ad31505804edced2a5ae77",
+                "sha256:2f7dbba46e2827dfcb0f0cc55fba8e96ba7c8700e0a866eb8cef7d1d66c25dcb",
+                "sha256:3ef655c51f41d5fa879f98e40c90072b567c666a7114fa2d9fe004dffba00932",
+                "sha256:5da894a29ec018a8293d3d17c797e73b374773943e8369cfc50495573d396933",
+                "sha256:755c22536d7f1889be25f2baf6fedd019d0c51d079e8417d4441159f3bcd30c2",
+                "sha256:7deb528029bacf845bdbb3dbb2927d8ef9b4356a5e731b10eef171e3f0a85944",
+                "sha256:9343690f95710f8cf251bee1013bf43030072b9f8d012fbed6ad702ef70d360a",
+                "sha256:a1f3ed501a42f60f4dedb7805fa8d4534e78b4e196f536bac926f805f0743d49",
+                "sha256:b08b356d06a792e49a12074b62222f9d4ea2a11dca9da9f68163b28c71bf1dd4",
+                "sha256:cc30a9053ff2f1ffb505a585797c23434d5f6c838bacfe206c0e6cf38c921a1e",
+                "sha256:d0d3d7ef3d4f06433d592e5f7d813314a34601e6c5be8481cccb7fa760aa243e",
+                "sha256:dd73fe7f4c28d317855da6a7bc4aa29a1500320818dd8f27df95f70a01b8171f",
+                "sha256:e1e0d4381ca88fb2b73ea0766008e703f33f460295de658f5467f6f229658c19",
+                "sha256:e3a4a6d46aef0a84b74fcd201a4401ea9a6cd85614f6a9435f2d33dd8cefbf83"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.3.0"
         },
         "s3transfer": {
             "hashes": [
@@ -1662,11 +1746,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401",
-                "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"
+                "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56",
+                "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.1.0"
+            "version": "==69.1.1"
         },
         "six": {
             "hashes": [
@@ -1693,11 +1777,11 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:06a859189a329ca8e66d56ceeef2391488e39b878fbd2141f115eab4d416fe22",
-                "sha256:f61a120d3e98ee1387bc5ca4b93437f258cc5c2af1f55f8634ec4cee5729f178"
+                "sha256:61811bbf4de95248939f9276a434be93d2b95f6ccfe8aa94e56999e9778cfcc2",
+                "sha256:79d5bfb01f64701b6cf442e89a37d9c4dc6dbb79a46f2f611739b2418d30ecfd"
             ],
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.20.3"
+            "version": "==0.20.5"
         },
         "types-jsonschema": {
             "hashes": [
@@ -1725,11 +1809,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:03a28ce1d7cd54199148e043b2079cdded22d6795d19a2c2a6791a4b2b5e2eb5",
-                "sha256:9592a9a4cb92d6d75d9b491a41477272b710e021011a2a3061157e2fb1f1a5d1"
+                "sha256:a82807ec6ddce8f00fe0e949da6d6bc1fbf1715420218a9640d695f70a9e5a9b",
+                "sha256:f1721dba8385958f504a5386240b92de4734e047a08a40751c1654d1ac3349c5"
             ],
             "index": "pypi",
-            "version": "==2.31.0.20240125"
+            "version": "==2.31.0.20240218"
         },
         "types-s3transfer": {
             "hashes": [
@@ -1741,11 +1825,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
             "markers": "python_version < '3.12'",
-            "version": "==4.9.0"
+            "version": "==4.10.0"
         },
         "urllib3": {
             "hashes": [
@@ -1757,11 +1841,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3",
-                "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"
+                "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a",
+                "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==20.25.0"
+            "version": "==20.25.1"
         },
         "wcwidth": {
             "hashes": [

--- a/docs/alma_harvests.md
+++ b/docs/alma_harvests.md
@@ -1,0 +1,47 @@
+# Alma GIS Harvests
+
+The following are sequence diagrams related to harvesting of GIS data from Alma MARC records.
+
+## Records added or modified in Alma invoking TIMDEX
+```mermaid
+sequenceDiagram
+    participant gis_team as GIS Team
+    participant alma_staff as Alma Staff
+    participant alma as Alma
+    participant s3_sftp as S3 SFTP
+    participant webhook as Alma Webhook Lambda
+    participant timdex_sf as TIMDEX StepFunction
+    
+    gis_team->>alma_staff: Create or help<br>identify GIS records
+    alma_staff->>alma: Create or modify records
+    alma->>s3_sftp: Daily and Full Exports<br>write records
+    alma->>webhook: Send TIMDEX<br>Export Confirmation
+    webhook->>timdex_sf: Invoke for TIMDEX<br>"alma" source 
+    note right of timdex_sf: Pre-existing "alma" invocation
+    webhook->>timdex_sf: Invoke for TIMDEX<br>"gisalma" source
+    note right of timdex_sf: New "gisalma" invocation
+```
+
+## GeoHarvester fetching and filtering Alma MARC records for `gisalma` source
+
+```mermaid
+sequenceDiagram
+    participant webhook as Alma Webhook Lambda
+    participant s3alma as TIMDEX s3 "alma" folder
+    participant gh as GeoHarvester
+    participant s3gisalma as TIMDEX s3 "gisalma" folder
+    participant geopipeline as Geo Records Pipeline
+    
+    webhook->>gh: Invoke "alma" harvest via CLI
+    gh->>s3alma: Identify records for scanning
+    s3alma-->>gh: Iterator of records
+    loop For each MARC record
+    	alt Matches geospatial filtering
+    		gh->>gh: Transform to MITAardvark
+    		gh->>s3gisalma: Write
+				else Does not match geospatial filtering
+				note right of gh: Skip
+    	end
+    end
+    gh->>geopipeline: Follows same pipeline as<br>"gismit" and "gisogm" from here
+```

--- a/harvester/harvest/alma.py
+++ b/harvester/harvest/alma.py
@@ -1,0 +1,192 @@
+"""harvester.harvest.alma"""
+
+import glob
+import logging
+import re
+from collections.abc import Iterator
+from typing import Literal, cast
+
+import smart_open  # type: ignore[import-untyped]
+from attrs import define, field
+from dateutil.parser import parse as date_parser
+from lxml import etree
+from marcalyx import Record as MARCRecord  # type: ignore[import-untyped]
+
+from harvester.aws.s3 import S3Client
+from harvester.config import Config
+from harvester.harvest import Harvester
+from harvester.records import (
+    MARC,
+    Record,
+)
+from harvester.utils import convert_to_utc
+
+logger = logging.getLogger(__name__)
+
+CONFIG = Config()
+
+
+@define
+class MITAlmaHarvester(Harvester):
+    """Harvester of MIT Alma MARC Records."""
+
+    input_files: str = field(default=None)
+
+    def full_harvest_get_source_records(self) -> Iterator[Record]:
+        """Identify files for harvest by parsing MARC records from FULL Alma exports."""
+        CONFIG.check_required_env_vars()
+        yield from self._get_source_records()
+
+    def incremental_harvest_get_source_records(self) -> Iterator[Record]:
+        """Identify files for harvest by parsing MARC records from DAILY Alma exports."""
+        CONFIG.check_required_env_vars()
+        yield from self._get_source_records()
+
+    def _get_source_records(self) -> Iterator[Record]:
+        """Shared method to get MARC records for full and incremental harvests."""
+        all_marc_records = self.parse_marc_records_from_files()
+        for marc_record in self.filter_geospatial_marc_records(all_marc_records):
+            identifier, source_record = self.create_source_record_from_marc_record(
+                marc_record
+            )
+            yield Record(
+                identifier=identifier,
+                source_record=source_record,
+            )
+
+    def _list_xml_files(self) -> Iterator[str]:
+        """Provide list of MARC record set XML files filtered by harvest type and date.
+
+        Example filepath: alma-2024-03-01-daily-extracted-records-to-index_19.xml
+            - run_type=extracted
+            - run_date=2024-03-01
+        """
+        if self.input_files.startswith("s3://"):
+            filepaths = self._list_s3_xml_files()
+        else:
+            filepaths = self._list_local_xml_files()  # pragma: nocover
+
+        harvest_type_map = {"full": "full", "incremental": "daily"}
+        date_regex = re.compile(r".+?alma-(\d{4}-\d{2}-\d{2})-.*")
+
+        for filepath in filepaths:
+
+            # skip for run type
+            if harvest_type_map[self.harvest_type] not in filepath:
+                continue
+
+            # parse date from filepath
+            match = date_regex.match(filepath)
+            if not match:  # pragma: nocover
+                message = f"Could not parse date from filepath: {filepath}"
+                logger.warning(message)
+                continue
+            filepath_date = convert_to_utc(date_parser(match.group(1)))
+
+            # skip if date out of bounds for harvester from/until dates
+            if self.from_datetime_object and filepath_date < self.from_datetime_object:
+                continue
+            if self.until_datetime_object and filepath_date >= self.until_datetime_object:
+                continue
+
+            yield filepath
+
+    def _list_s3_xml_files(self) -> list[str]:
+        """Return a list of S3 URIs for extracted Alma XML files.
+
+        Example self.input_files = "s3://timdex-extract-dev-222053980223/alma/"
+        """
+        bucket, prefix = self.input_files.replace("s3://", "").split("/", 1)
+        s3_objects = S3Client.list_objects_uri_and_date(bucket, prefix)
+        return [
+            s3_object[0]
+            for s3_object in s3_objects
+            if s3_object[0].lower().endswith(".xml")
+        ]
+
+    def _list_local_xml_files(self) -> list[str]:
+        """Return a list of local filepaths of extracted Alma XML files."""
+        return glob.glob(f"{self.input_files.removesuffix('/')}/*.xml")
+
+    def parse_marc_records_from_files(self) -> Iterator[MARCRecord]:
+        """Yield parsed MARCRecords from list of filepaths."""
+        for filepath in self._list_xml_files():
+            with smart_open.open(filepath, "rb") as f:
+                context = etree.iterparse(f, events=("end",), tag="record")
+                for _event, elem in context:
+                    yield MARCRecord(elem)
+                    elem.clear()
+                    while elem.getprevious() is not None:
+                        del elem.getparent()[0]
+
+    def filter_geospatial_marc_records(
+        self, marc_records: Iterator[MARCRecord]
+    ) -> Iterator[MARCRecord]:
+        """Yield geospatial MARC records by filtering on defined criteria."""
+        for i, record in enumerate(marc_records):
+            if i % 10_000 == 0 and i > 0:  # pragma: nocover
+                message = f"{i} MARC records scanned for geospatial filtering"
+                logger.info(message)
+
+            # skip if leader doesn't have a/c/n/p
+            if record.leader[5] not in ("a", "c", "n", "p"):
+                continue
+
+            # skip if Genre/Form 655 does not contain "Maps."
+            if not any(
+                "Maps." in subfield.value
+                for form in record["655"]
+                for subfield in form.subfield("a")
+            ):
+                continue
+
+            # skip if call number prefix not in list
+            if not any(
+                subfield.value in ("MAP", "CDROM", "DVDROM")
+                for locations in record["949"]
+                for subfield in locations.subfield("k")
+            ):
+                continue
+
+            # skip if shelving location not in list
+            if not any(
+                subfield.value in ("MAPRM", "GIS")
+                for locations in record["985"]
+                for subfield in locations.subfield("aa")
+            ):
+                continue
+
+            yield record
+
+    def create_source_record_from_marc_record(
+        self, marc_record: MARCRecord
+    ) -> tuple[str, MARC]:
+        """Create MARC SourceRecord from parsed MARC record."""
+        # derive identifier from ControlField 001
+        try:
+            identifier = next(
+                item for item in marc_record.controlFields() if item.tag == "001"
+            ).value
+        except IndexError as exc:  # pragma: nocover
+            message = "Could not extract identifier from ControlField 001"
+            raise ValueError(message) from exc
+
+        # derive event from Leader 5th character
+        event: Literal["created", "deleted"] = cast(
+            Literal["created", "deleted"],
+            {
+                "a": "created",
+                "c": "created",
+                "n": "created",
+                "p": "created",
+                "d": "deleted",
+            }[marc_record.leader[5]],
+        )
+
+        return identifier, MARC(
+            origin="mit",
+            identifier=identifier,
+            data=etree.tostring(marc_record.node),
+            marc=marc_record,
+            event=event,
+        )

--- a/harvester/harvest/alma.py
+++ b/harvester/harvest/alma.py
@@ -184,7 +184,7 @@ class MITAlmaHarvester(Harvester):
         )
 
         return identifier, MARC(
-            origin="mit",
+            origin="alma",
             identifier=identifier,
             data=etree.tostring(marc_record.node),
             marc=marc_record,

--- a/harvester/records/__init__.py
+++ b/harvester/records/__init__.py
@@ -13,3 +13,4 @@ from harvester.records.fgdc import FGDC
 from harvester.records.iso19139 import ISO19139
 from harvester.records.gbl1 import GBL1
 from harvester.records.aardvark import Aardvark
+from harvester.records.marc import MARC

--- a/harvester/records/marc.py
+++ b/harvester/records/marc.py
@@ -1,0 +1,89 @@
+"""harvester.harvest.records.marc"""
+
+# ruff: noqa: N802
+
+from typing import Literal
+
+from attrs import define, field
+
+from harvester.records.record import XMLSourceRecord
+
+
+@define
+class MARC(XMLSourceRecord):
+    """MIT MARC metadata format SourceRecord class."""
+
+    metadata_format: Literal["marc"] = field(default="marc")
+
+    ##########################
+    # Required Field Methods
+    ##########################
+
+    def _dct_accessRights_s(self) -> str:
+        raise NotImplementedError
+
+    def _dct_title_s(self) -> str | None:
+        raise NotImplementedError
+
+    def _gbl_resourceClass_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dcat_bbox(self) -> str | None:
+        raise NotImplementedError
+
+    def _locn_geometry(self) -> str | None:
+        raise NotImplementedError
+
+    ##########################
+    # Optional Field Methods
+    ##########################
+
+    def _dct_description_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dcat_keyword_sm(self) -> list[str]:
+        """New field in Aardvark: no mapping from GBL1 to dcat_keyword_sm."""
+        raise NotImplementedError
+
+    def _dct_alternative_sm(self) -> list[str]:
+        """New field in Aardvark: no mapping from GBL1 to dct_alternative_sm."""
+        raise NotImplementedError
+
+    def _dct_creator_sm(self) -> list[str] | None:
+        raise NotImplementedError
+
+    def _dct_format_s(self) -> str | None:
+        raise NotImplementedError
+
+    def _dct_issued_s(self) -> str | None:
+        raise NotImplementedError
+
+    def _dct_identifier_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dct_language_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dct_publisher_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dct_rights_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _dct_spatial_sm(self) -> list[str] | None:
+        raise NotImplementedError
+
+    def _dct_subject_sm(self) -> list[str] | None:
+        raise NotImplementedError
+
+    def _dct_temporal_sm(self) -> list[str] | None:
+        raise NotImplementedError
+
+    def _gbl_dateRange_drsim(self) -> list[str]:
+        raise NotImplementedError
+
+    def _gbl_resourceType_sm(self) -> list[str]:
+        raise NotImplementedError
+
+    def _gbl_indexYear_im(self) -> list[int]:
+        raise NotImplementedError

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -160,7 +160,7 @@ class SourceRecord:
         ogm_repo_config: config dictionary of OGM repository from configuration YAML
     """
 
-    origin: Literal["mit", "ogm"] = field(validator=in_(["mit", "ogm"]))
+    origin: Literal["alma", "mit", "ogm"] = field(validator=in_(["alma", "mit", "ogm"]))
     identifier: str = field(validator=instance_of(str))
     metadata_format: Literal["fgdc", "iso19139", "gbl1", "aardvark", "marc"] = field(
         validator=in_(["fgdc", "iso19139", "gbl1", "aardvark", "marc"])
@@ -474,6 +474,8 @@ class SourceRecord:
         For OGM harvests, provider will come from named defined in OGM configuration YAML.
         """
         match self.origin:
+            case "alma":
+                return "MIT Libraries"
             case "mit":
                 return "GIS Lab, MIT Libraries"
             case "ogm":

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 from attrs import asdict, define, field, fields
 from attrs.validators import in_, instance_of
 from lxml import etree  # type: ignore[import-untyped]
+from marcalyx import Record as MARCRecord  # type: ignore[import-untyped]
 
 from harvester.aws.sqs import ZipFileEventMessage
 from harvester.config import Config
@@ -161,8 +162,8 @@ class SourceRecord:
 
     origin: Literal["mit", "ogm"] = field(validator=in_(["mit", "ogm"]))
     identifier: str = field(validator=instance_of(str))
-    metadata_format: Literal["fgdc", "iso19139", "gbl1", "aardvark"] = field(
-        validator=in_(["fgdc", "iso19139", "gbl1", "aardvark"])
+    metadata_format: Literal["fgdc", "iso19139", "gbl1", "aardvark", "marc"] = field(
+        validator=in_(["fgdc", "iso19139", "gbl1", "aardvark", "marc"])
     )
     data: str | bytes = field(repr=False)
     zip_file_location: str = field(default=None)
@@ -171,6 +172,7 @@ class SourceRecord:
     )
     sqs_message: ZipFileEventMessage = field(default=None)
     ogm_repo_config: dict = field(default=None)
+    marc: MARCRecord = field(default=None)
 
     @property
     def output_filename_extension(self) -> str:

--- a/tests/fixtures/alma/s3_folder/alma-2023-12-31-daily-extracted-records-to-index_01.xml
+++ b/tests/fixtures/alma/s3_folder/alma-2023-12-31-daily-extracted-records-to-index_01.xml
@@ -1,0 +1,641 @@
+<collection>
+    <!-- Non geospatial record -->
+    <record>
+        <leader>01288nam 2200349K 4500</leader>
+        <controlfield tag="005">20231210212752.0</controlfield>
+        <controlfield tag="008">910304s1990 xx a b 000 0 eng d</controlfield>
+        <controlfield tag="001">990004672550106761</controlfield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)23183280</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">MYG</subfield>
+            <subfield code="c">MYG</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGT [Eng]</subfield>
+            <subfield code="a">[Micro-] [fiche] MYGE</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="a">Thesis M.E. 1990 B.S. Mfch</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis</subfield>
+            <subfield code="a">M.E.</subfield>
+            <subfield code="a">1990</subfield>
+            <subfield code="a">B.S.</subfield>
+        </datafield>
+        <datafield tag="100" ind1="1" ind2=" ">
+            <subfield code="a">Vega, Hyun-Ju.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Acoustic emission signals from the sliding interface of two
+                metals /
+            </subfield>
+            <subfield code="c">by Hyun-Ju Vega.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="c">c1990.</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">64 leaves :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="b">B.S.</subfield>
+            <subfield code="c">Massachusetts Institute of Technology, Department of
+                Mechanical Engineering
+            </subfield>
+            <subfield code="d">1990</subfield>
+        </datafield>
+        <datafield tag="504" ind1=" " ind2=" ">
+            <subfield code="a">Includes bibliographical references (leaf 64).</subfield>
+        </datafield>
+        <datafield tag="599" ind1=" " ind2=" ">
+            <subfield code="a">GRSN 467255</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Massachusetts Institute of Technology.</subfield>
+            <subfield code="b">Department of Mechanical Engineering.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">ajf</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2=" ">
+            <subfield code="a">MYTT</subfield>
+            <subfield code="b">39080006707506</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTT</subfield>
+            <subfield code="b">39080006713165</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTE</subfield>
+            <subfield code="b">39080006712894</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">1990</subfield>
+            <subfield code="a">xx</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">23183280</subfield>
+        </datafield>
+        <datafield tag="992" ind1="0" ind2="0">
+            <subfield code="a">Supervised by Ming-Kai Tse.</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ENG</subfield>
+            <subfield code="d">MFORM</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574790006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN1</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574770006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN3</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574810006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">MFORM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006712894</subfield>
+            <subfield code="a">23522574780006761</subfield>
+            <subfield code="c">12</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ENG</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN1</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006713165</subfield>
+            <subfield code="a">23522574760006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN3</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006707506</subfield>
+            <subfield code="a">23522574800006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+    </record>
+    <!-- Geospatial records -->
+    <record>
+        <leader>02642cem 2200637 a 4500</leader>
+        <controlfield tag="005">20231211171314.0</controlfield>
+        <controlfield tag="007">aj canzn</controlfield>
+        <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+        <controlfield tag="001">990022897960106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">80692167</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">0906358019</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="034" ind1="0" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="d">E0503300</subfield>
+            <subfield code="e">E0503300</subfield>
+            <subfield code="f">N0260139</subfield>
+            <subfield code="g">N0260139</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)002289796MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06533196</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCA</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-ba---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1="0" ind2="0">
+            <subfield code="a">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7590</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7594</subfield>
+            <subfield code="b">M3</subfield>
+        </datafield>
+        <datafield tag="110" ind1="2" ind2=" ">
+            <subfield code="a">Fairey Surveys Ltd.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="h">[cartographic material] /</subfield>
+            <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+            </subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scales vary</subfield>
+            <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+            </subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire :</subfield>
+            <subfield code="b">Fairey,</subfield>
+            <subfield code="c">[1979?]</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">5 maps :</subfield>
+            <subfield code="b">both sides, col. ;</subfield>
+            <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+                cm.
+            </subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">nb</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Fairey/Falcon map series</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Printed on both sides of sheet.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+                handy reference source for the visitor to Bahrain / designed, edited &amp;
+                published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+                International Ltd., London, Eng. (40 p. ; 22 cm.).
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="0" ind2=" ">
+            <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+                -- 4. Al Jufayr -- Al Manamah.
+            </subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Bahrain.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Manama (Bahrain)</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Falcon Publishing.</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Parrish Rogers International Ltd.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">Fairey/Falcon map series.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy140828</subfield>
+            <subfield code="b">copy</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">blank</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">r-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">140828</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">r-map</subfield>
+            <subfield code="b">RTC</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080036498050</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+            <subfield code="a">1979</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7590 1979.F3</subfield>
+            <subfield code="a">06533196</subfield>
+            <subfield code="a">80692167</subfield>
+            <subfield code="a">0906358019</subfield>
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="990" ind1=" " ind2=" ">
+            <subfield code="a">MIT Rotch Library copy of map without text booklet.
+            </subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">RTC</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7590 1979.F3</subfield>
+            <subfield code="8">22467461200006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080036498050</subfield>
+            <subfield code="a">23467461190006761</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7590 1979.F3</subfield>
+            <subfield code="i">RTC</subfield>
+        </datafield>
+    </record>
+    <record>
+        <leader>02540cem 2200613Ia 4500</leader>
+        <controlfield tag="005">20231211141912.0</controlfield>
+        <controlfield tag="008">800822m19419999enkag a f 1 eng</controlfield>
+        <controlfield tag="001">990019938100106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="034" ind1="1" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="b">50000</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)001993810MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06644794</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">GAT</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">STF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-tu---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1=" " ind2="4">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="b">.G72</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7430</subfield>
+        </datafield>
+        <datafield tag="090" ind1=" " ind2=" ">
+            <subfield code="a">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="110" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">War Office.</subfield>
+            <subfield code="b">General Staff.</subfield>
+            <subfield code="b">Geographical Section.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">1:200,000 Turkey</subfield>
+            <subfield code="h">[cartographic material].</subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scale 1:200,000. 1 inch = 3.16 miles.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">[London]</subfield>
+            <subfield code="b">War Office,</subfield>
+            <subfield code="c">1941-</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">maps :</subfield>
+            <subfield code="b">col. ;</subfield>
+            <subfield code="c">43 x 53 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">zu</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Its [G.S.G.S.] ;</subfield>
+            <subfield code="v">4193</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Relief shown by contours and spot heights.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Set includes various issues of some sheets, some reissued
+                by U.S. Army Map Service. Some are by British Middle East Forces (M.D.R.
+                3) with or without series designation Provisional G.S.G.S. 4193.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">"Longitudes are from Istanbul. Greenwich longitude of
+                Istanbul is 28&#8304;59 &#769;east, approximately."
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Contours are shown at 25, 50, 100 and 500 meters.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Military grid.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Two classes of railroads, six classes of roads and paths
+                and various types of vegetation shown.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Based on Turkish maps.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Marginal maps on various sheets include index to adjoining
+                sheets, incidence of grid letters, key to grids and index to boundaries.
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="1" ind2=" ">
+            <subfield code="a">Sheet A 8. Inebolu</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="0">
+            <subfield code="a">Geology</subfield>
+            <subfield code="z">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="7">
+            <subfield code="a">Geology.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Turkey.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="810" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">Army.</subfield>
+            <subfield code="b">Middle East Forces.</subfield>
+            <subfield code="t">M.D.R. ;</subfield>
+            <subfield code="v">3.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">GSGS (Series) ;</subfield>
+            <subfield code="v">4193.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy110824</subfield>
+            <subfield code="b">mod</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">I</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">s-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">110824</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">s-map</subfield>
+            <subfield code="b">SCI</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080035090411</subfield>
+            <subfield code="v">Sheet A 8 Inebolu</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">[London] War Office, 9999</subfield>
+            <subfield code="a">1941 9999</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="a">06644794</subfield>
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">SCI</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7431.C5 s200.G72</subfield>
+            <subfield code="8">22518012960006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080035090411</subfield>
+            <subfield code="a">23518012940006761</subfield>
+            <subfield code="g">Sheet A 8 Inebolu</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7431.C5 s200.G72</subfield>
+            <subfield code="i">SCI</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/tests/fixtures/alma/s3_folder/alma-2023-12-31-full-extracted-records-to-index_01.xml
+++ b/tests/fixtures/alma/s3_folder/alma-2023-12-31-full-extracted-records-to-index_01.xml
@@ -1,0 +1,641 @@
+<collection>
+    <!-- Non geospatial record -->
+    <record>
+        <leader>01288nam 2200349K 4500</leader>
+        <controlfield tag="005">20231210212752.0</controlfield>
+        <controlfield tag="008">910304s1990 xx a b 000 0 eng d</controlfield>
+        <controlfield tag="001">990004672550106761</controlfield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)23183280</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">MYG</subfield>
+            <subfield code="c">MYG</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGT [Eng]</subfield>
+            <subfield code="a">[Micro-] [fiche] MYGE</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="a">Thesis M.E. 1990 B.S. Mfch</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis</subfield>
+            <subfield code="a">M.E.</subfield>
+            <subfield code="a">1990</subfield>
+            <subfield code="a">B.S.</subfield>
+        </datafield>
+        <datafield tag="100" ind1="1" ind2=" ">
+            <subfield code="a">Vega, Hyun-Ju.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Acoustic emission signals from the sliding interface of two
+                metals /
+            </subfield>
+            <subfield code="c">by Hyun-Ju Vega.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="c">c1990.</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">64 leaves :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="b">B.S.</subfield>
+            <subfield code="c">Massachusetts Institute of Technology, Department of
+                Mechanical Engineering
+            </subfield>
+            <subfield code="d">1990</subfield>
+        </datafield>
+        <datafield tag="504" ind1=" " ind2=" ">
+            <subfield code="a">Includes bibliographical references (leaf 64).</subfield>
+        </datafield>
+        <datafield tag="599" ind1=" " ind2=" ">
+            <subfield code="a">GRSN 467255</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Massachusetts Institute of Technology.</subfield>
+            <subfield code="b">Department of Mechanical Engineering.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">ajf</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2=" ">
+            <subfield code="a">MYTT</subfield>
+            <subfield code="b">39080006707506</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTT</subfield>
+            <subfield code="b">39080006713165</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTE</subfield>
+            <subfield code="b">39080006712894</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">1990</subfield>
+            <subfield code="a">xx</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">23183280</subfield>
+        </datafield>
+        <datafield tag="992" ind1="0" ind2="0">
+            <subfield code="a">Supervised by Ming-Kai Tse.</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ENG</subfield>
+            <subfield code="d">MFORM</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574790006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN1</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574770006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN3</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574810006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">MFORM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006712894</subfield>
+            <subfield code="a">23522574780006761</subfield>
+            <subfield code="c">12</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ENG</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN1</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006713165</subfield>
+            <subfield code="a">23522574760006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN3</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006707506</subfield>
+            <subfield code="a">23522574800006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+    </record>
+    <!-- Geospatial records -->
+    <record>
+        <leader>02642cem 2200637 a 4500</leader>
+        <controlfield tag="005">20231211171314.0</controlfield>
+        <controlfield tag="007">aj canzn</controlfield>
+        <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+        <controlfield tag="001">990022897960106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">80692167</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">0906358019</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="034" ind1="0" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="d">E0503300</subfield>
+            <subfield code="e">E0503300</subfield>
+            <subfield code="f">N0260139</subfield>
+            <subfield code="g">N0260139</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)002289796MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06533196</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCA</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-ba---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1="0" ind2="0">
+            <subfield code="a">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7590</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7594</subfield>
+            <subfield code="b">M3</subfield>
+        </datafield>
+        <datafield tag="110" ind1="2" ind2=" ">
+            <subfield code="a">Fairey Surveys Ltd.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="h">[cartographic material] /</subfield>
+            <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+            </subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scales vary</subfield>
+            <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+            </subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire :</subfield>
+            <subfield code="b">Fairey,</subfield>
+            <subfield code="c">[1979?]</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">5 maps :</subfield>
+            <subfield code="b">both sides, col. ;</subfield>
+            <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+                cm.
+            </subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">nb</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Fairey/Falcon map series</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Printed on both sides of sheet.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+                handy reference source for the visitor to Bahrain / designed, edited &amp;
+                published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+                International Ltd., London, Eng. (40 p. ; 22 cm.).
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="0" ind2=" ">
+            <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+                -- 4. Al Jufayr -- Al Manamah.
+            </subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Bahrain.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Manama (Bahrain)</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Falcon Publishing.</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Parrish Rogers International Ltd.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">Fairey/Falcon map series.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy140828</subfield>
+            <subfield code="b">copy</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">blank</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">r-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">140828</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">r-map</subfield>
+            <subfield code="b">RTC</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080036498050</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+            <subfield code="a">1979</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7590 1979.F3</subfield>
+            <subfield code="a">06533196</subfield>
+            <subfield code="a">80692167</subfield>
+            <subfield code="a">0906358019</subfield>
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="990" ind1=" " ind2=" ">
+            <subfield code="a">MIT Rotch Library copy of map without text booklet.
+            </subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">RTC</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7590 1979.F3</subfield>
+            <subfield code="8">22467461200006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080036498050</subfield>
+            <subfield code="a">23467461190006761</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7590 1979.F3</subfield>
+            <subfield code="i">RTC</subfield>
+        </datafield>
+    </record>
+    <record>
+        <leader>02540cem 2200613Ia 4500</leader>
+        <controlfield tag="005">20231211141912.0</controlfield>
+        <controlfield tag="008">800822m19419999enkag a f 1 eng</controlfield>
+        <controlfield tag="001">990019938100106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="034" ind1="1" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="b">50000</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)001993810MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06644794</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">GAT</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">STF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-tu---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1=" " ind2="4">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="b">.G72</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7430</subfield>
+        </datafield>
+        <datafield tag="090" ind1=" " ind2=" ">
+            <subfield code="a">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="110" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">War Office.</subfield>
+            <subfield code="b">General Staff.</subfield>
+            <subfield code="b">Geographical Section.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">1:200,000 Turkey</subfield>
+            <subfield code="h">[cartographic material].</subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scale 1:200,000. 1 inch = 3.16 miles.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">[London]</subfield>
+            <subfield code="b">War Office,</subfield>
+            <subfield code="c">1941-</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">maps :</subfield>
+            <subfield code="b">col. ;</subfield>
+            <subfield code="c">43 x 53 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">zu</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Its [G.S.G.S.] ;</subfield>
+            <subfield code="v">4193</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Relief shown by contours and spot heights.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Set includes various issues of some sheets, some reissued
+                by U.S. Army Map Service. Some are by British Middle East Forces (M.D.R.
+                3) with or without series designation Provisional G.S.G.S. 4193.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">"Longitudes are from Istanbul. Greenwich longitude of
+                Istanbul is 28&#8304;59 &#769;east, approximately."
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Contours are shown at 25, 50, 100 and 500 meters.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Military grid.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Two classes of railroads, six classes of roads and paths
+                and various types of vegetation shown.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Based on Turkish maps.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Marginal maps on various sheets include index to adjoining
+                sheets, incidence of grid letters, key to grids and index to boundaries.
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="1" ind2=" ">
+            <subfield code="a">Sheet A 8. Inebolu</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="0">
+            <subfield code="a">Geology</subfield>
+            <subfield code="z">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="7">
+            <subfield code="a">Geology.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Turkey.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="810" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">Army.</subfield>
+            <subfield code="b">Middle East Forces.</subfield>
+            <subfield code="t">M.D.R. ;</subfield>
+            <subfield code="v">3.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">GSGS (Series) ;</subfield>
+            <subfield code="v">4193.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy110824</subfield>
+            <subfield code="b">mod</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">I</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">s-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">110824</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">s-map</subfield>
+            <subfield code="b">SCI</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080035090411</subfield>
+            <subfield code="v">Sheet A 8 Inebolu</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">[London] War Office, 9999</subfield>
+            <subfield code="a">1941 9999</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="a">06644794</subfield>
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">SCI</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7431.C5 s200.G72</subfield>
+            <subfield code="8">22518012960006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080035090411</subfield>
+            <subfield code="a">23518012940006761</subfield>
+            <subfield code="g">Sheet A 8 Inebolu</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7431.C5 s200.G72</subfield>
+            <subfield code="i">SCI</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/tests/fixtures/alma/s3_folder/alma-2024-01-01-daily-extracted-records-to-index_01.xml
+++ b/tests/fixtures/alma/s3_folder/alma-2024-01-01-daily-extracted-records-to-index_01.xml
@@ -1,0 +1,641 @@
+<collection>
+    <!-- Non geospatial record -->
+    <record>
+        <leader>01288nam 2200349K 4500</leader>
+        <controlfield tag="005">20231210212752.0</controlfield>
+        <controlfield tag="008">910304s1990 xx a b 000 0 eng d</controlfield>
+        <controlfield tag="001">990004672550106761</controlfield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)23183280</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">MYG</subfield>
+            <subfield code="c">MYG</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGT [Eng]</subfield>
+            <subfield code="a">[Micro-] [fiche] MYGE</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="a">Thesis M.E. 1990 B.S. Mfch</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis</subfield>
+            <subfield code="a">M.E.</subfield>
+            <subfield code="a">1990</subfield>
+            <subfield code="a">B.S.</subfield>
+        </datafield>
+        <datafield tag="100" ind1="1" ind2=" ">
+            <subfield code="a">Vega, Hyun-Ju.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Acoustic emission signals from the sliding interface of two
+                metals /
+            </subfield>
+            <subfield code="c">by Hyun-Ju Vega.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="c">c1990.</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">64 leaves :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="b">B.S.</subfield>
+            <subfield code="c">Massachusetts Institute of Technology, Department of
+                Mechanical Engineering
+            </subfield>
+            <subfield code="d">1990</subfield>
+        </datafield>
+        <datafield tag="504" ind1=" " ind2=" ">
+            <subfield code="a">Includes bibliographical references (leaf 64).</subfield>
+        </datafield>
+        <datafield tag="599" ind1=" " ind2=" ">
+            <subfield code="a">GRSN 467255</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Massachusetts Institute of Technology.</subfield>
+            <subfield code="b">Department of Mechanical Engineering.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">ajf</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2=" ">
+            <subfield code="a">MYTT</subfield>
+            <subfield code="b">39080006707506</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTT</subfield>
+            <subfield code="b">39080006713165</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTE</subfield>
+            <subfield code="b">39080006712894</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">1990</subfield>
+            <subfield code="a">xx</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">23183280</subfield>
+        </datafield>
+        <datafield tag="992" ind1="0" ind2="0">
+            <subfield code="a">Supervised by Ming-Kai Tse.</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ENG</subfield>
+            <subfield code="d">MFORM</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574790006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN1</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574770006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN3</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574810006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">MFORM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006712894</subfield>
+            <subfield code="a">23522574780006761</subfield>
+            <subfield code="c">12</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ENG</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN1</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006713165</subfield>
+            <subfield code="a">23522574760006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN3</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006707506</subfield>
+            <subfield code="a">23522574800006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+    </record>
+    <!-- Geospatial records -->
+    <record>
+        <leader>02642cem 2200637 a 4500</leader>
+        <controlfield tag="005">20231211171314.0</controlfield>
+        <controlfield tag="007">aj canzn</controlfield>
+        <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+        <controlfield tag="001">990022897960106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">80692167</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">0906358019</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="034" ind1="0" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="d">E0503300</subfield>
+            <subfield code="e">E0503300</subfield>
+            <subfield code="f">N0260139</subfield>
+            <subfield code="g">N0260139</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)002289796MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06533196</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCA</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-ba---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1="0" ind2="0">
+            <subfield code="a">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7590</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7594</subfield>
+            <subfield code="b">M3</subfield>
+        </datafield>
+        <datafield tag="110" ind1="2" ind2=" ">
+            <subfield code="a">Fairey Surveys Ltd.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="h">[cartographic material] /</subfield>
+            <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+            </subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scales vary</subfield>
+            <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+            </subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire :</subfield>
+            <subfield code="b">Fairey,</subfield>
+            <subfield code="c">[1979?]</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">5 maps :</subfield>
+            <subfield code="b">both sides, col. ;</subfield>
+            <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+                cm.
+            </subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">nb</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Fairey/Falcon map series</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Printed on both sides of sheet.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+                handy reference source for the visitor to Bahrain / designed, edited &amp;
+                published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+                International Ltd., London, Eng. (40 p. ; 22 cm.).
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="0" ind2=" ">
+            <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+                -- 4. Al Jufayr -- Al Manamah.
+            </subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Bahrain.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Manama (Bahrain)</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Falcon Publishing.</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Parrish Rogers International Ltd.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">Fairey/Falcon map series.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy140828</subfield>
+            <subfield code="b">copy</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">blank</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">r-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">140828</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">r-map</subfield>
+            <subfield code="b">RTC</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080036498050</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+            <subfield code="a">1979</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7590 1979.F3</subfield>
+            <subfield code="a">06533196</subfield>
+            <subfield code="a">80692167</subfield>
+            <subfield code="a">0906358019</subfield>
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="990" ind1=" " ind2=" ">
+            <subfield code="a">MIT Rotch Library copy of map without text booklet.
+            </subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">RTC</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7590 1979.F3</subfield>
+            <subfield code="8">22467461200006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080036498050</subfield>
+            <subfield code="a">23467461190006761</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7590 1979.F3</subfield>
+            <subfield code="i">RTC</subfield>
+        </datafield>
+    </record>
+    <record>
+        <leader>02540cem 2200613Ia 4500</leader>
+        <controlfield tag="005">20231211141912.0</controlfield>
+        <controlfield tag="008">800822m19419999enkag a f 1 eng</controlfield>
+        <controlfield tag="001">990019938100106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="034" ind1="1" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="b">50000</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)001993810MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06644794</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">GAT</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">STF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-tu---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1=" " ind2="4">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="b">.G72</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7430</subfield>
+        </datafield>
+        <datafield tag="090" ind1=" " ind2=" ">
+            <subfield code="a">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="110" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">War Office.</subfield>
+            <subfield code="b">General Staff.</subfield>
+            <subfield code="b">Geographical Section.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">1:200,000 Turkey</subfield>
+            <subfield code="h">[cartographic material].</subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scale 1:200,000. 1 inch = 3.16 miles.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">[London]</subfield>
+            <subfield code="b">War Office,</subfield>
+            <subfield code="c">1941-</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">maps :</subfield>
+            <subfield code="b">col. ;</subfield>
+            <subfield code="c">43 x 53 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">zu</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Its [G.S.G.S.] ;</subfield>
+            <subfield code="v">4193</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Relief shown by contours and spot heights.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Set includes various issues of some sheets, some reissued
+                by U.S. Army Map Service. Some are by British Middle East Forces (M.D.R.
+                3) with or without series designation Provisional G.S.G.S. 4193.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">"Longitudes are from Istanbul. Greenwich longitude of
+                Istanbul is 28&#8304;59 &#769;east, approximately."
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Contours are shown at 25, 50, 100 and 500 meters.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Military grid.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Two classes of railroads, six classes of roads and paths
+                and various types of vegetation shown.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Based on Turkish maps.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Marginal maps on various sheets include index to adjoining
+                sheets, incidence of grid letters, key to grids and index to boundaries.
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="1" ind2=" ">
+            <subfield code="a">Sheet A 8. Inebolu</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="0">
+            <subfield code="a">Geology</subfield>
+            <subfield code="z">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="7">
+            <subfield code="a">Geology.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Turkey.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="810" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">Army.</subfield>
+            <subfield code="b">Middle East Forces.</subfield>
+            <subfield code="t">M.D.R. ;</subfield>
+            <subfield code="v">3.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">GSGS (Series) ;</subfield>
+            <subfield code="v">4193.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy110824</subfield>
+            <subfield code="b">mod</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">I</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">s-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">110824</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">s-map</subfield>
+            <subfield code="b">SCI</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080035090411</subfield>
+            <subfield code="v">Sheet A 8 Inebolu</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">[London] War Office, 9999</subfield>
+            <subfield code="a">1941 9999</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="a">06644794</subfield>
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">SCI</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7431.C5 s200.G72</subfield>
+            <subfield code="8">22518012960006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080035090411</subfield>
+            <subfield code="a">23518012940006761</subfield>
+            <subfield code="g">Sheet A 8 Inebolu</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7431.C5 s200.G72</subfield>
+            <subfield code="i">SCI</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/tests/fixtures/alma/s3_folder/alma-2024-01-01-full-extracted-records-to-index_01.xml
+++ b/tests/fixtures/alma/s3_folder/alma-2024-01-01-full-extracted-records-to-index_01.xml
@@ -1,0 +1,641 @@
+<collection>
+    <!-- Non geospatial record -->
+    <record>
+        <leader>01288nam 2200349K 4500</leader>
+        <controlfield tag="005">20231210212752.0</controlfield>
+        <controlfield tag="008">910304s1990 xx a b 000 0 eng d</controlfield>
+        <controlfield tag="001">990004672550106761</controlfield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)000467255MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)23183280</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">MYG</subfield>
+            <subfield code="c">MYG</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGT [Eng]</subfield>
+            <subfield code="a">[Micro-] [fiche] MYGE</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="a">Thesis M.E. 1990 B.S. Mfch</subfield>
+        </datafield>
+        <datafield tag="099" ind1=" " ind2=" ">
+            <subfield code="a">Thesis</subfield>
+            <subfield code="a">M.E.</subfield>
+            <subfield code="a">1990</subfield>
+            <subfield code="a">B.S.</subfield>
+        </datafield>
+        <datafield tag="100" ind1="1" ind2=" ">
+            <subfield code="a">Vega, Hyun-Ju.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Acoustic emission signals from the sliding interface of two
+                metals /
+            </subfield>
+            <subfield code="c">by Hyun-Ju Vega.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="c">c1990.</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">64 leaves :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="b">B.S.</subfield>
+            <subfield code="c">Massachusetts Institute of Technology, Department of
+                Mechanical Engineering
+            </subfield>
+            <subfield code="d">1990</subfield>
+        </datafield>
+        <datafield tag="504" ind1=" " ind2=" ">
+            <subfield code="a">Includes bibliographical references (leaf 64).</subfield>
+        </datafield>
+        <datafield tag="599" ind1=" " ind2=" ">
+            <subfield code="a">GRSN 467255</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Massachusetts Institute of Technology.</subfield>
+            <subfield code="b">Department of Mechanical Engineering.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">ajf</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2=" ">
+            <subfield code="a">MYTT</subfield>
+            <subfield code="b">39080006707506</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTT</subfield>
+            <subfield code="b">39080006713165</subfield>
+            <subfield code="a">[Micro-] [fiche] MYTE</subfield>
+            <subfield code="b">39080006712894</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">1990</subfield>
+            <subfield code="a">xx</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">23183280</subfield>
+        </datafield>
+        <datafield tag="992" ind1="0" ind2="0">
+            <subfield code="a">Supervised by Ming-Kai Tse.</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ENG</subfield>
+            <subfield code="d">MFORM</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574790006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN1</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574770006761</subfield>
+        </datafield>
+        <datafield tag="900" ind1="8" ind2=" ">
+            <subfield code="b">ARC</subfield>
+            <subfield code="d">NOLN3</subfield>
+            <subfield code="f">Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="8">22522574810006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">MFORM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006712894</subfield>
+            <subfield code="a">23522574780006761</subfield>
+            <subfield code="c">12</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ENG</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN1</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006713165</subfield>
+            <subfield code="a">23522574760006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">8</subfield>
+            <subfield code="aa">NOLN3</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080006707506</subfield>
+            <subfield code="a">23522574800006761</subfield>
+            <subfield code="c">02</subfield>
+            <subfield code="bb">THESIS Thesis M.E. 1990 B.S.</subfield>
+            <subfield code="i">ARC</subfield>
+        </datafield>
+    </record>
+    <!-- Geospatial records -->
+    <record>
+        <leader>02642cem 2200637 a 4500</leader>
+        <controlfield tag="005">20231211171314.0</controlfield>
+        <controlfield tag="007">aj canzn</controlfield>
+        <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+        <controlfield tag="001">990022897960106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">80692167</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">0906358019</subfield>
+        </datafield>
+        <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="034" ind1="0" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="d">E0503300</subfield>
+            <subfield code="e">E0503300</subfield>
+            <subfield code="f">N0260139</subfield>
+            <subfield code="g">N0260139</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)002289796MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06533196</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCA</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-ba---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1="0" ind2="0">
+            <subfield code="a">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7590</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7594</subfield>
+            <subfield code="b">M3</subfield>
+        </datafield>
+        <datafield tag="110" ind1="2" ind2=" ">
+            <subfield code="a">Fairey Surveys Ltd.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="h">[cartographic material] /</subfield>
+            <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+            </subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scales vary</subfield>
+            <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+            </subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire :</subfield>
+            <subfield code="b">Fairey,</subfield>
+            <subfield code="c">[1979?]</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">5 maps :</subfield>
+            <subfield code="b">both sides, col. ;</subfield>
+            <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+                cm.
+            </subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">nb</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Fairey/Falcon map series</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Printed on both sides of sheet.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+                handy reference source for the visitor to Bahrain / designed, edited &amp;
+                published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+                International Ltd., London, Eng. (40 p. ; 22 cm.).
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="0" ind2=" ">
+            <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+                -- 4. Al Jufayr -- Al Manamah.
+            </subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Bahrain.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Bahrain</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Manama (Bahrain)</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Road maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Tourist maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Falcon Publishing.</subfield>
+        </datafield>
+        <datafield tag="710" ind1="2" ind2=" ">
+            <subfield code="a">Parrish Rogers International Ltd.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">Fairey/Falcon map series.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy140828</subfield>
+            <subfield code="b">copy</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">blank</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">r-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">140828</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">r-map</subfield>
+            <subfield code="b">RTC</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080036498050</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7590 1979.F3</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+            <subfield code="a">1979</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7590 1979.F3</subfield>
+            <subfield code="a">06533196</subfield>
+            <subfield code="a">80692167</subfield>
+            <subfield code="a">0906358019</subfield>
+            <subfield code="a">9780906358016</subfield>
+        </datafield>
+        <datafield tag="990" ind1=" " ind2=" ">
+            <subfield code="a">MIT Rotch Library copy of map without text booklet.
+            </subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">RTC</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7590 1979.F3</subfield>
+            <subfield code="8">22467461200006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080036498050</subfield>
+            <subfield code="a">23467461190006761</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7590 1979.F3</subfield>
+            <subfield code="i">RTC</subfield>
+        </datafield>
+    </record>
+    <record>
+        <leader>02540cem 2200613Ia 4500</leader>
+        <controlfield tag="005">20231211141912.0</controlfield>
+        <controlfield tag="008">800822m19419999enkag a f 1 eng</controlfield>
+        <controlfield tag="001">990019938100106761</controlfield>
+        <datafield tag="010" ind1=" " ind2=" ">
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="034" ind1="1" ind2=" ">
+            <subfield code="a">a</subfield>
+            <subfield code="b">50000</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(MCM)001993810MIT01</subfield>
+        </datafield>
+        <datafield tag="035" ind1=" " ind2=" ">
+            <subfield code="a">(OCoLC)06644794</subfield>
+        </datafield>
+        <datafield tag="040" ind1=" " ind2=" ">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">GAT</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">STF</subfield>
+            <subfield code="d">MYG</subfield>
+        </datafield>
+        <datafield tag="043" ind1=" " ind2=" ">
+            <subfield code="a">a-tu---</subfield>
+        </datafield>
+        <datafield tag="049" ind1=" " ind2=" ">
+            <subfield code="a">MYGG</subfield>
+        </datafield>
+        <datafield tag="050" ind1=" " ind2="4">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="b">.G72</subfield>
+        </datafield>
+        <datafield tag="052" ind1=" " ind2=" ">
+            <subfield code="a">7430</subfield>
+        </datafield>
+        <datafield tag="090" ind1=" " ind2=" ">
+            <subfield code="a">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="110" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">War Office.</subfield>
+            <subfield code="b">General Staff.</subfield>
+            <subfield code="b">Geographical Section.</subfield>
+        </datafield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">1:200,000 Turkey</subfield>
+            <subfield code="h">[cartographic material].</subfield>
+        </datafield>
+        <datafield tag="255" ind1=" " ind2=" ">
+            <subfield code="a">Scale 1:200,000. 1 inch = 3.16 miles.</subfield>
+        </datafield>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">[London]</subfield>
+            <subfield code="b">War Office,</subfield>
+            <subfield code="c">1941-</subfield>
+        </datafield>
+        <datafield tag="300" ind1=" " ind2=" ">
+            <subfield code="a">maps :</subfield>
+            <subfield code="b">col. ;</subfield>
+            <subfield code="c">43 x 53 cm.</subfield>
+        </datafield>
+        <datafield tag="336" ind1=" " ind2=" ">
+            <subfield code="a">cartographic image</subfield>
+            <subfield code="b">cri</subfield>
+            <subfield code="2">rdacontent</subfield>
+        </datafield>
+        <datafield tag="337" ind1=" " ind2=" ">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+        </datafield>
+        <datafield tag="338" ind1=" " ind2=" ">
+            <subfield code="a">sheet</subfield>
+            <subfield code="b">zu</subfield>
+            <subfield code="2">rdacarrier</subfield>
+        </datafield>
+        <datafield tag="490" ind1="1" ind2=" ">
+            <subfield code="a">Its [G.S.G.S.] ;</subfield>
+            <subfield code="v">4193</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Relief shown by contours and spot heights.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Set includes various issues of some sheets, some reissued
+                by U.S. Army Map Service. Some are by British Middle East Forces (M.D.R.
+                3) with or without series designation Provisional G.S.G.S. 4193.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">"Longitudes are from Istanbul. Greenwich longitude of
+                Istanbul is 28&#8304;59 &#769;east, approximately."
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Contours are shown at 25, 50, 100 and 500 meters.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Military grid.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Two classes of railroads, six classes of roads and paths
+                and various types of vegetation shown.
+            </subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Based on Turkish maps.</subfield>
+        </datafield>
+        <datafield tag="500" ind1=" " ind2=" ">
+            <subfield code="a">Marginal maps on various sheets include index to adjoining
+                sheets, incidence of grid letters, key to grids and index to boundaries.
+            </subfield>
+        </datafield>
+        <datafield tag="505" ind1="1" ind2=" ">
+            <subfield code="a">Sheet A 8. Inebolu</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="0">
+            <subfield code="a">Geology</subfield>
+            <subfield code="z">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="650" ind1=" " ind2="7">
+            <subfield code="a">Geology.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="0">
+            <subfield code="a">Turkey</subfield>
+            <subfield code="v">Maps.</subfield>
+        </datafield>
+        <datafield tag="651" ind1=" " ind2="7">
+            <subfield code="a">Turkey.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">lcgft</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="655" ind1=" " ind2="7">
+            <subfield code="a">Topographic maps.</subfield>
+            <subfield code="2">fast</subfield>
+        </datafield>
+        <datafield tag="810" ind1="1" ind2=" ">
+            <subfield code="a">Great Britain.</subfield>
+            <subfield code="b">Army.</subfield>
+            <subfield code="b">Middle East Forces.</subfield>
+            <subfield code="t">M.D.R. ;</subfield>
+            <subfield code="v">3.</subfield>
+        </datafield>
+        <datafield tag="830" ind1=" " ind2="0">
+            <subfield code="a">GSGS (Series) ;</subfield>
+            <subfield code="v">4193.</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">mjy110824</subfield>
+            <subfield code="b">mod</subfield>
+            <subfield code="c">~</subfield>
+            <subfield code="e">wall</subfield>
+            <subfield code="j">e</subfield>
+            <subfield code="k">m</subfield>
+            <subfield code="l">blank</subfield>
+            <subfield code="m">I</subfield>
+            <subfield code="o">a</subfield>
+            <subfield code="p">DLC</subfield>
+            <subfield code="q">s-map</subfield>
+            <subfield code="r">a</subfield>
+            <subfield code="s">1</subfield>
+            <subfield code="w">~</subfield>
+            <subfield code="x">0</subfield>
+            <subfield code="y">~</subfield>
+            <subfield code="z">~</subfield>
+            <subfield code="i">mjy</subfield>
+            <subfield code="d">110824</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+        </datafield>
+        <datafield tag="910" ind1=" " ind2=" ">
+            <subfield code="a">MARCIVEAUT231209</subfield>
+        </datafield>
+        <datafield tag="949" ind1=" " ind2="0">
+            <subfield code="4">IP</subfield>
+            <subfield code="a">s-map</subfield>
+            <subfield code="b">SCI</subfield>
+            <subfield code="c">MAPRM</subfield>
+            <subfield code="k">MAP</subfield>
+            <subfield code="o">0</subfield>
+            <subfield code="p">39080035090411</subfield>
+            <subfield code="v">Sheet A 8 Inebolu</subfield>
+            <subfield code="x">04</subfield>
+            <subfield code="h">G7431.C5 s200.G72</subfield>
+        </datafield>
+        <datafield tag="961" ind1=" " ind2=" ">
+            <subfield code="a">[London] War Office, 9999</subfield>
+            <subfield code="a">1941 9999</subfield>
+            <subfield code="a">enk</subfield>
+        </datafield>
+        <datafield tag="969" ind1=" " ind2=" ">
+            <subfield code="a">G7430 S200</subfield>
+            <subfield code="a">06644794</subfield>
+            <subfield code="a">map47000005</subfield>
+        </datafield>
+        <datafield tag="994" ind1=" " ind2=" ">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+        </datafield>
+        <datafield tag="900" ind1="0" ind2=" ">
+            <subfield code="b">SCI</subfield>
+            <subfield code="d">MAPRM</subfield>
+            <subfield code="f">G7431.C5 s200.G72</subfield>
+            <subfield code="8">22518012960006761</subfield>
+        </datafield>
+        <datafield tag="985" ind1=" " ind2=" ">
+            <subfield code="j">0</subfield>
+            <subfield code="aa">MAPRM</subfield>
+            <subfield code="t">BOOK</subfield>
+            <subfield code="s">39080035090411</subfield>
+            <subfield code="a">23518012940006761</subfield>
+            <subfield code="g">Sheet A 8 Inebolu</subfield>
+            <subfield code="c">04</subfield>
+            <subfield code="bb">MAP G7431.C5 s200.G72</subfield>
+            <subfield code="i">SCI</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/tests/fixtures/alma/s3_folder/file_filtering_should_ignore.txt
+++ b/tests/fixtures/alma/s3_folder/file_filtering_should_ignore.txt
@@ -1,0 +1,1 @@
+This file should be excluded from filtering.

--- a/tests/fixtures/alma/single_records/geospatial_fail_655.xml
+++ b/tests/fixtures/alma/single_records/geospatial_fail_655.xml
@@ -1,0 +1,220 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">N0260139</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_fail_949.xml
+++ b/tests/fixtures/alma/single_records/geospatial_fail_949.xml
@@ -1,0 +1,243 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">N0260139</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_fail_985.xml
+++ b/tests/fixtures/alma/single_records/geospatial_fail_985.xml
@@ -1,0 +1,243 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">N0260139</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_fail_leader.xml
+++ b/tests/fixtures/alma/single_records/geospatial_fail_leader.xml
@@ -1,0 +1,239 @@
+<record>
+    <leader>02540xem 2200613Ia 4500</leader>
+    <controlfield tag="005">20231211141912.0</controlfield>
+    <controlfield tag="008">800822m19419999enkag a f 1 eng</controlfield>
+    <controlfield tag="001">990019938100106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">map47000005</subfield>
+    </datafield>
+    <datafield tag="034" ind1="1" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="b">50000</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)001993810MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06644794</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="c">GAT</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">STF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-tu---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1=" " ind2="4">
+        <subfield code="a">G7430 S200</subfield>
+        <subfield code="b">.G72</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7430</subfield>
+    </datafield>
+    <datafield tag="090" ind1=" " ind2=" ">
+        <subfield code="a">G7431.C5 s200.G72</subfield>
+    </datafield>
+    <datafield tag="110" ind1="1" ind2=" ">
+        <subfield code="a">Great Britain.</subfield>
+        <subfield code="b">War Office.</subfield>
+        <subfield code="b">General Staff.</subfield>
+        <subfield code="b">Geographical Section.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">1:200,000 Turkey</subfield>
+        <subfield code="h">[cartographic material].</subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scale 1:200,000. 1 inch = 3.16 miles.</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">[London]</subfield>
+        <subfield code="b">War Office,</subfield>
+        <subfield code="c">1941-</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">maps :</subfield>
+        <subfield code="b">col. ;</subfield>
+        <subfield code="c">43 x 53 cm.</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">zu</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Its [G.S.G.S.] ;</subfield>
+        <subfield code="v">4193</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Relief shown by contours and spot heights.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Set includes various issues of some sheets, some reissued
+            by U.S. Army Map Service. Some are by British Middle East Forces (M.D.R.
+            3) with or without series designation Provisional G.S.G.S. 4193.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">"Longitudes are from Istanbul. Greenwich longitude of
+            Istanbul is 28&#8304;59 &#769;east, approximately."
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Contours are shown at 25, 50, 100 and 500 meters.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Military grid.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Two classes of railroads, six classes of roads and paths
+            and various types of vegetation shown.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Based on Turkish maps.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Marginal maps on various sheets include index to adjoining
+            sheets, incidence of grid letters, key to grids and index to boundaries.
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="1" ind2=" ">
+        <subfield code="a">Sheet A 8. Inebolu</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+        <subfield code="a">Geology</subfield>
+        <subfield code="z">Turkey</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="7">
+        <subfield code="a">Geology.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Turkey</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Turkey.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Topographic maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Topographic maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="810" ind1="1" ind2=" ">
+        <subfield code="a">Great Britain.</subfield>
+        <subfield code="b">Army.</subfield>
+        <subfield code="b">Middle East Forces.</subfield>
+        <subfield code="t">M.D.R. ;</subfield>
+        <subfield code="v">3.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">GSGS (Series) ;</subfield>
+        <subfield code="v">4193.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy110824</subfield>
+        <subfield code="b">mod</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">I</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">s-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">110824</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">s-map</subfield>
+        <subfield code="b">SCI</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080035090411</subfield>
+        <subfield code="v">Sheet A 8 Inebolu</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7431.C5 s200.G72</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">[London] War Office, 9999</subfield>
+        <subfield code="a">1941 9999</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7430 S200</subfield>
+        <subfield code="a">06644794</subfield>
+        <subfield code="a">map47000005</subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">SCI</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7431.C5 s200.G72</subfield>
+        <subfield code="8">22518012960006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080035090411</subfield>
+        <subfield code="a">23518012940006761</subfield>
+        <subfield code="g">Sheet A 8 Inebolu</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7431.C5 s200.G72</subfield>
+        <subfield code="i">SCI</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_valid.xml
+++ b/tests/fixtures/alma/single_records/geospatial_valid.xml
@@ -1,0 +1,244 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">N0260139</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/test_harvest/test_alma_harvester.py
+++ b/tests/test_harvest/test_alma_harvester.py
@@ -13,56 +13,56 @@ def marc_record_generator(file_path):
 
 def test_alma_harvester_list_local_xml_files(alma_harvester):
     alma_harvester.input_files = "tests/fixtures/alma/s3_folder"
-    assert alma_harvester._list_local_xml_files() == [
+    assert set(alma_harvester._list_local_xml_files()) == {
         "tests/fixtures/alma/s3_folder/alma-2023-12-31-daily-extracted-records-to-index_01.xml",
         "tests/fixtures/alma/s3_folder/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
         "tests/fixtures/alma/s3_folder/alma-2023-12-31-full-extracted-records-to-index_01.xml",
         "tests/fixtures/alma/s3_folder/alma-2024-01-01-full-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_list_s3_xml_files(alma_harvester):
-    assert alma_harvester._list_s3_xml_files() == [
+    assert set(alma_harvester._list_s3_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2023-12-31-daily-extracted-records-to-index_01.xml",
         "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_list_xml_files_filter_run_type(alma_harvester):
     # full harvest = "full" in filename
     alma_harvester.harvest_type = "full"
-    assert list(alma_harvester._list_xml_files()) == [
+    assert set(alma_harvester._list_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
-    ]
+    }
     # incremental harvest = "daily" in filename
     alma_harvester.harvest_type = "incremental"
-    assert list(alma_harvester._list_xml_files()) == [
+    assert set(alma_harvester._list_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_list_xml_files_filter_from_date(alma_harvester):
     alma_harvester.from_date, alma_harvester.until_date = "2024-01-01", None
-    assert list(alma_harvester._list_xml_files()) == [
+    assert set(alma_harvester._list_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_list_xml_files_filter_until_date(alma_harvester):
     alma_harvester.from_date, alma_harvester.until_date = None, "2024-01-01"
-    assert list(alma_harvester._list_xml_files()) == [
+    assert set(alma_harvester._list_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_list_xml_files_filter_from_to_until_dates(alma_harvester):
     alma_harvester.from_date, alma_harvester.until_date = "2023-12-01", "2024-02-01"
-    assert list(alma_harvester._list_xml_files()) == [
+    assert set(alma_harvester._list_xml_files()) == {
         "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
         "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
-    ]
+    }
 
 
 def test_alma_harvester_parse_marcalyx_marc_record_objects_from_xml_file(alma_harvester):

--- a/tests/test_harvest/test_alma_harvester.py
+++ b/tests/test_harvest/test_alma_harvester.py
@@ -1,0 +1,116 @@
+"""tests.test_harvest.test_alma_harvester"""
+
+# ruff: noqa: SLF001, PLR2004
+
+import marcalyx
+from lxml import etree
+
+
+def marc_record_generator(file_path):
+    with open(file_path, "rb") as file:
+        yield marcalyx.Record(etree.fromstring(file.read()).getroottree().getroot())
+
+
+def test_alma_harvester_list_local_xml_files(alma_harvester):
+    alma_harvester.input_files = "tests/fixtures/alma/s3_folder"
+    assert alma_harvester._list_local_xml_files() == [
+        "tests/fixtures/alma/s3_folder/alma-2023-12-31-daily-extracted-records-to-index_01.xml",
+        "tests/fixtures/alma/s3_folder/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
+        "tests/fixtures/alma/s3_folder/alma-2023-12-31-full-extracted-records-to-index_01.xml",
+        "tests/fixtures/alma/s3_folder/alma-2024-01-01-full-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_list_s3_xml_files(alma_harvester):
+    assert alma_harvester._list_s3_xml_files() == [
+        "s3://mocked-timdex-bucket/alma/alma-2023-12-31-daily-extracted-records-to-index_01.xml",
+        "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_list_xml_files_filter_run_type(alma_harvester):
+    # full harvest = "full" in filename
+    alma_harvester.harvest_type = "full"
+    assert list(alma_harvester._list_xml_files()) == [
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
+    ]
+    # incremental harvest = "daily" in filename
+    alma_harvester.harvest_type = "incremental"
+    assert list(alma_harvester._list_xml_files()) == [
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-daily-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_list_xml_files_filter_from_date(alma_harvester):
+    alma_harvester.from_date, alma_harvester.until_date = "2024-01-01", None
+    assert list(alma_harvester._list_xml_files()) == [
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_list_xml_files_filter_until_date(alma_harvester):
+    alma_harvester.from_date, alma_harvester.until_date = None, "2024-01-01"
+    assert list(alma_harvester._list_xml_files()) == [
+        "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_list_xml_files_filter_from_to_until_dates(alma_harvester):
+    alma_harvester.from_date, alma_harvester.until_date = "2023-12-01", "2024-02-01"
+    assert list(alma_harvester._list_xml_files()) == [
+        "s3://mocked-timdex-bucket/alma/alma-2023-12-31-full-extracted-records-to-index_01.xml",
+        "s3://mocked-timdex-bucket/alma/alma-2024-01-01-full-extracted-records-to-index_01.xml",
+    ]
+
+
+def test_alma_harvester_parse_marcalyx_marc_record_objects_from_xml_file(alma_harvester):
+    record = next(alma_harvester.parse_marc_records_from_files())
+    assert isinstance(record, marcalyx.Record)
+
+
+def test_alma_harvester_filter_geospatial_records_count(alma_harvester):
+    all_marc_records = alma_harvester.parse_marc_records_from_files()
+    records = list(alma_harvester.filter_geospatial_marc_records(all_marc_records))
+    assert len(records) == 2
+
+
+def test_alma_harvester_filter_geospatial_fail_leader_code(alma_harvester):
+    records_iter = marc_record_generator(
+        "tests/fixtures/alma/single_records/geospatial_fail_leader.xml"
+    )
+    assert len(list(alma_harvester.filter_geospatial_marc_records(records_iter))) == 0
+
+
+def test_alma_harvester_filter_geospatial_fail_655_tag(alma_harvester):
+    records_iter = marc_record_generator(
+        "tests/fixtures/alma/single_records/geospatial_fail_655.xml"
+    )
+    assert len(list(alma_harvester.filter_geospatial_marc_records(records_iter))) == 0
+
+
+def test_alma_harvester_filter_geospatial_fail_949_tag(alma_harvester):
+    records_iter = marc_record_generator(
+        "tests/fixtures/alma/single_records/geospatial_fail_949.xml"
+    )
+    assert len(list(alma_harvester.filter_geospatial_marc_records(records_iter))) == 0
+
+
+def test_alma_harvester_filter_geospatial_fail_985_tag(alma_harvester):
+    records_iter = marc_record_generator(
+        "tests/fixtures/alma/single_records/geospatial_fail_985.xml"
+    )
+    assert len(list(alma_harvester.filter_geospatial_marc_records(records_iter))) == 0
+
+
+def test_alma_harvester_get_source_records_full(alma_harvester):
+    alma_harvester.harvest_type = "full"
+    records = list(alma_harvester.get_source_records())
+    assert len(records) == 2
+
+
+def test_alma_harvester_get_source_records_incremental(alma_harvester):
+    alma_harvester.harvest_type = "incremental"
+    records = list(alma_harvester.get_source_records())
+    assert len(records) == 2


### PR DESCRIPTION
### Purpose and background context
This PR introduces the ability for GeoHarvester to harvest Alma MARC records.  This first update only includes the ability to fetch and filter geospatial MARC records from S3.  The files it is targeting are MARC XML files deposited by the TIMDEX Alma exports.

By introducing a new `MITAlmaHarvester` harvester, this paves the way for a new `gisalma` TIMDEX source that would sit alongside of `gismit` and `gisogm`.

It has been observed that this is not the most efficient way to harvest a subset of Alma MARC records that meet our geospatial requirements, but it is a path with minimal (if any) infrastructure changes at the moment.  If and when other mechanisms to produce a smaller subset of Alma MARC records emerge, this harvester could be updated to point at a different location, but the mechanics should remain largely the same, potentially with some filtering still happening at this application level.

PR review notes and areas of focus:
- the python library [marcalyx](https://pypi.org/project/marcalyx/) was selected to parse MARC XML records
  - because it parses from an XML string, well suited for the lazy evaluation approach of scanning through records; vs `pymarc` which is more aligned with reading directly from a file-object
- the `MARC` `SourceRecord` class is **stubbed** at this time to support the full `get_source_records()` functionality 
  -  no field methods are defined yet, which is slated for [GDT-227](https://mitlibraries.atlassian.net/browse/GDT-227)
- the methods `full_harvest_get_source_records()` and `incremental_harvest_get_source_records()` both point to the same method `_get_source_records()`
  - the addition of the CLI command may tweak this slightly, but unlike MIT and OGM harvesters, the mechanics are virtually the same, just driven entirely through `harvest-type` and `from-date / until-date` properties

### How can a reviewer manually see the effects of these changes?

As there is no CLI command yet for `gisalma` harvests, a python shell is required:

```python
import logging
from harvester.config import configure_logger
from harvester.harvest.alma import MITAlmaHarvester

root_logger = logging.getLogger()
configure_logger(root_logger, True)

# init harvester that will read from S3
harvester = MITAlmaHarvester(
    input_files="s3://timdex-extract-dev-222053980223/alma",
    harvest_type="full",
    from_date="2023-01-13",
    until_date="2023-01-14",
)

# get iterator of records
records = harvester.full_harvest_get_source_records()

# scan until first record that matches geospatial MARC filtering
record = next(records)

# assert both raw XML stored and parsed MARCRecord on record.source_record
assert record.source_record.data.startswith(b"<record><leader>02723nem  2200589Ii 4500</leader>")
assert record.source_record.marc.titleStatement().value.startswith("Gravity-Bouguer anomalies, Ottawa Islands, Northwest Territories")
```

To also get a sense of how the harvester scans through many MARC records but filters to a subset:
```python
import itertools

# retrieve 100 records demonstrating scan through 50k+ records
# (if performed in same python console with logger set to DEBUG above, will see logging outputs)
record_subset = list(itertools.islice(records, 100))
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-226

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes



[GDT-227]: https://mitlibraries.atlassian.net/browse/GDT-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ