### PR TITLE
Encapsulate SourceRecord source and metadata format logic

### DIFF
--- a/docs/metadata_normalization.md
+++ b/docs/metadata_normalization.md
@@ -1,8 +1,8 @@
 # Metadata Normalization to MIT Aardvark
 
-A primary action performed by this harvester is normalizing metadata records from FGDC, ISO19139, GeoBlacklight 1.x (GBL1), or Aardvark formats into an MIT compliant Aardvark metadata record.  These normalized MIT Aardvark records are ultimately what will be indexed into TIMDEX.
+A primary action performed by this harvester is normalizing metadata records from FGDC, ISO19139, GeoBlacklight 1.x (GBL1), Aardvark,  or MARC formats into an MIT compliant Aardvark metadata record.  These normalized MIT Aardvark records are ultimately what will be indexed into TIMDEX.
 
-## Record Classes
+## Record Class
 
 ```mermaid
 classDiagram
@@ -14,10 +14,10 @@ classDiagram
         exception: Exception
     }
     class SourceRecord{
+        origin: str
         event: str
         data: str|bytes
         metadata_format: str
-        zip_file_location: str
         normalize() -> MITAardvark
     }
     class MITAardvark{
@@ -26,67 +26,83 @@ classDiagram
         [...all Aardvark fields]*
         validate()
     }
-    class XMLSourceRecord{
-        [...shared XML behavior]*
-    }
-    class JSONSourceRecord{
-        [...shared JSON behavior]*
-    }
-    class FGDC{
-        xml_tree: lxml.ElementTree
-        _dct_title_s()
-        _locn_geometry()
-        ...other_fields()*
-    }
-    class ISO19139{
-        xml_tree: lxml.ElementTree
-        _dct_title_s()
-        _locn_geometry()
-        ...other_fields()*
-    }
-    class GBL{
-        @data_dict: dict
-        _dct_title_s()
-        _locn_geometry()
-        ...other_fields()*
-    }
-    class Aardvark{
-        @data_dict: dict
-        _dct_title_s()
-        _locn_geometry()
-        ...other_fields()*
-    }
     
     Record <-- SourceRecord
-    Record <-- MITAardvark
-    SourceRecord <|-- XMLSourceRecord
-    SourceRecord <|-- JSONSourceRecord
-    XMLSourceRecord <|-- FGDC
-    XMLSourceRecord <|-- ISO19139
-    JSONSourceRecord <|-- GBL
-    JSONSourceRecord <|-- Aardvark
+    Record <-- MITAardvark    
 ```
 
 - `Record`
   - represents a single geospatial resource
   - attributes `source_record` and `normalized_record` hold its original (source) and normalized metadata records
 - `SourceRecord`
+  - `Record.source_record`
   - represents the original, source metadata record
   - `normalize()` is the primary entrypoint method for normalization to a new `MITAardvark` instance
-  - extended by other classes -- `FGDC`, `ISO19139`, `GBL1`, and `Aardvark` -- that define per-Aardvark field methods that provide values for those fields
+  - see more about the creation of `SourceRecords` below
 - `MITAardvark`
+  - `Record.normalized_record` 
   - represents a normalized form of the source metadata as an MIT-compliant [Aardvark](https://opengeometadata.org/ogm-aardvark/) record
-  - this class has ALL standard Aardvark fields as class fields
-  - this class ALSO contains a few MIT extensions to the Aardvark format with an `mit_` prefix
-- `FGDC`, `ISO19139`, `GBL1`, `Aardvark`
-  - classes that extend `SourceRecord` for a given metadata format
-  - these classes define methods that return values from the original source data for a new `MITAardvark` record 
+  - this class has all standard Aardvark fields as class fields
+
+## SourceRecord
+
+A `SourceRecord` instance is ultimately a composite class that combines properties and methods from two types of subclasses:
+  * Origin
+    * classes with behavior specific to the record origin
+    * found in `harvester.records.source`
+  * Metadata Format
+    * classes with behavior specific to the metadata format
+    * found in `harvester.records.format`
+
+This arrangement allows for any combination of origin and metadata formats.  Classes layer on additional methods and properties as needed.  
+
+The following shows an example of a `MITFGDC(MITSourceRecord, FGDC)` class used for MIT harvests that inherits from both `MITSourceRecord` (origin) and `FGDC` (metadata format).
+
+```mermaid
+classDiagram
+    class MITFGDC{
+        origin: str
+        metadata_format: str
+        event: str
+        data: str|bytes
+        normalize() -> MITAardvark
+    }
+    class MITSourceRecord{
+        origin: str
+        zip_file_location: str
+        sqs_message: dict
+        [...shared_field_methods]*
+    }
+    class FGDC{
+        metadata_format: str
+        [...field_methods]*
+    }
+    class XMLSourceRecord{
+        xml_tree: lxml.ElementTree
+        [...shared XML behavior]*
+    }    
+    class SourceRecord{
+        event: str
+        data: str|bytes
+        normalize() -> MITAardvark
+    }
+    
+    
+    MITFGDC <-- MITSourceRecord
+    MITFGDC <-- FGDC
+    FGDC <-- XMLSourceRecord
+    XMLSourceRecord <-- SourceRecord
+    MITSourceRecord <-- SourceRecord
+    
+```
+
+Similarly, for OGM harvests you find the class `OGMGBL1(OGMSourceRecord, GBL1)` which inherits logic for OGM harvests and `GBL1` normalization.
 
 ## Normalization
 
-Normalization from a "source" record to a "normalized" MITAardvark relies on a tightly coupled naming convention of field names defined in the `MITAardvark` class and methods defined on classes `FGDC`, `ISO19139`, `GBL1`, and `Aardvark` (not MIT Aardvark records) that extend `SourceRecord`.
+Normalization from a "source" record to a "normalized" MITAardvark relies on a tightly coupled naming convention of field names defined in the `MITAardvark` class and methods defined on classes metadata format classes (e.g. `FGDC`, `GBL1`, etc.).
 
-When `SourceRecord.normalize()` is called, field names are retrieved from the `MITAardvark` class.  The method then looks for methods defined by `FGDC`, `ISO19139`, `GBL1`, and `Aardvark` that correlate with this field name.  If the method is found, it's run, and the value returned becomes the value in the new `MITAardvark` instance.  
+When `SourceRecord.normalize()` is called, field names are retrieved from the `MITAardvark` class.  The method then looks for methods defined by metadata classes that correlate with this field name.  If the method is found, it's run, and the value returned becomes the value in the new `MITAardvark` instance.  
 
 For example, for field `MITAardvark.dct_title_s`, the `SourceRecord.normalize()` method would look for a method `_dct_title_s()` on the extending child class.  If the method does not exist, the field is skipped.  But if present, that method should return a valid value for that field.
 
@@ -101,7 +117,7 @@ Once all field names + methods are exhausted, a new instance of `MITAardvark` is
 sequenceDiagram
     autonumber
     
-    participant meta as FGDC|ISO19139|GBL1|Aardvark
+    participant meta as Metadata Format Classes
     participant sr as SourceRecord
     participant mita as MITAardvark Class
     participant mita_new as New MITAardvark Instance

--- a/harvester/harvest/alma.py
+++ b/harvester/harvest/alma.py
@@ -15,7 +15,8 @@ from marcalyx import Record as MARCRecord  # type: ignore[import-untyped]
 from harvester.aws.s3 import S3Client
 from harvester.config import Config
 from harvester.harvest import Harvester
-from harvester.records import MARC, Record
+from harvester.records import Record
+from harvester.records.sources.alma import AlmaMARC
 from harvester.utils import convert_to_utc
 
 logger = logging.getLogger(__name__)
@@ -182,7 +183,7 @@ class MITAlmaHarvester(Harvester):
 
     def create_source_record_from_marc_record(
         self, marc_record: MARCRecord
-    ) -> tuple[str, MARC]:
+    ) -> tuple[str, AlmaMARC]:
         """Create MARC SourceRecord from parsed MARC record."""
         # derive identifier from ControlField 001
         try:
@@ -205,8 +206,7 @@ class MITAlmaHarvester(Harvester):
             }[marc_record.leader[5]],
         )
 
-        return identifier, MARC(
-            origin="alma",
+        return identifier, AlmaMARC(
             identifier=identifier,
             data=etree.tostring(marc_record.node),
             marc=marc_record,

--- a/harvester/harvest/ogm.py
+++ b/harvester/harvest/ogm.py
@@ -23,12 +23,14 @@ from harvester.harvest.exceptions import (
     OGMFromDateExceedsEpochDateError,
 )
 from harvester.records import (
-    FGDC,
-    GBL1,
-    ISO19139,
-    Aardvark,
     Record,
     SourceRecord,
+)
+from harvester.records.sources.ogm import (
+    OGMFGDC,
+    OGMGBL1,
+    OGMISO19139,
+    OGMAardvark,
 )
 from harvester.utils import date_parser
 
@@ -145,16 +147,15 @@ class OGMHarvester(Harvester):
     ) -> SourceRecord:
         """Create source record."""
         source_record_class = {
-            "gbl1": GBL1,
-            "aardvark": Aardvark,
-            "fgdc": FGDC,
-            "iso19139": ISO19139,
+            "gbl1": OGMGBL1,
+            "aardvark": OGMAardvark,
+            "fgdc": OGMFGDC,
+            "iso19139": OGMISO19139,
         }[metadata_format]
         return source_record_class(
             identifier=identifier,
             data=data,
             event=change_type,
-            origin="ogm",
             ogm_repo_config=ogm_repo_config,
         )
 

--- a/harvester/records/__init__.py
+++ b/harvester/records/__init__.py
@@ -1,4 +1,4 @@
-"""harvester.harvest.records"""
+"""harvester.records"""
 
 # ruff: noqa: I001,F401
 
@@ -9,8 +9,3 @@ from harvester.records.record import (
     XMLSourceRecord,
     JSONSourceRecord,
 )
-from harvester.records.fgdc import FGDC
-from harvester.records.iso19139 import ISO19139
-from harvester.records.gbl1 import GBL1
-from harvester.records.aardvark import Aardvark
-from harvester.records.marc import MARC

--- a/harvester/records/formats/__init__.py
+++ b/harvester/records/formats/__init__.py
@@ -1,0 +1,9 @@
+"""harvester.records.formats"""
+
+# ruff: noqa: I001,F401
+
+from harvester.records.formats.aardvark import Aardvark
+from harvester.records.formats.fgdc import FGDC
+from harvester.records.formats.iso19139 import ISO19139
+from harvester.records.formats.marc import MARC
+from harvester.records.formats.gbl1 import GBL1

--- a/harvester/records/formats/aardvark.py
+++ b/harvester/records/formats/aardvark.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from attrs import define, field
 
+from harvester.records.formats.helpers import gbl_resource_class_value_map
 from harvester.records.record import JSONSourceRecord
 
 
@@ -28,9 +29,7 @@ class Aardvark(JSONSourceRecord):
     def _gbl_resourceClass_sm(self) -> list[str]:
         mapped_values = []
         for value in self.parsed_data.get("gbl_resourceClass_sm", []):
-            if mapped_value := self.gbl_resource_class_value_map.get(
-                value.strip().lower()
-            ):
+            if mapped_value := gbl_resource_class_value_map().get(value.strip().lower()):
                 mapped_values.append(mapped_value)  # noqa: PERF401
         return mapped_values if mapped_values else ["Other"]
 

--- a/harvester/records/formats/aardvark.py
+++ b/harvester/records/formats/aardvark.py
@@ -1,8 +1,7 @@
-"""harvester.harvest.records.aardvark"""
+"""harvester.records.formats.aardvark"""
 
 # ruff: noqa: N802
 
-import json
 from typing import Literal
 
 from attrs import define, field
@@ -12,10 +11,7 @@ from harvester.records.record import JSONSourceRecord
 
 @define
 class Aardvark(JSONSourceRecord):
-    """GeoBlacklight4.x (Aardvark) metadata format SourceRecord class.
-
-    NOTE: This source record class is only used for OGM harvests.
-    """
+    """GeoBlacklight4.x (Aardvark) metadata format SourceRecord class."""
 
     metadata_format: Literal["aardvark"] = field(default="aardvark")
 
@@ -43,38 +39,6 @@ class Aardvark(JSONSourceRecord):
 
     def _locn_geometry(self) -> str | None:
         return self.parsed_data.get("locn_geometry", None)
-
-    def _dct_references_s_ogm(self) -> dict:
-        """Field method helper: "dct_references_s"
-
-        For OGM repositories that provide Aardvark metadata, the most reliable location
-        to find an external URL is the 'http://schema.org/url' key in the dct_references_s
-        JSON payload.
-
-        If the URI "http://schema.org/downloadUrl" is present, and only a single value,
-        use.  If array, skip, as cannot be sure of a single download link to choose from.
-        """
-        refs_dict = json.loads(self.parsed_data["dct_references_s"])
-
-        # extract required external URL
-        url = refs_dict.get("http://schema.org/url")
-        if not url:
-            error_message = "Could not determine external URL from source metadata"
-            raise ValueError(error_message)
-        urls_dict = {"http://schema.org/url": url}
-
-        # extract optional download url
-        download_uri = "http://schema.org/downloadUrl"
-        if download_value := refs_dict.get(download_uri):  # noqa: SIM102
-            if isinstance(download_value, str):
-                urls_dict[download_uri] = [
-                    {
-                        "label": "Data",
-                        "url": download_value,
-                    }
-                ]
-
-        return urls_dict
 
     ##########################
     # Optional Field Methods

--- a/harvester/records/formats/fgdc.py
+++ b/harvester/records/formats/fgdc.py
@@ -1,4 +1,4 @@
-"""harvester.harvest.records.fgdc"""
+"""harvester.records.formats.fgdc"""
 
 # ruff: noqa: N802, N815; allows camelCase for aardvark fields
 

--- a/harvester/records/formats/gbl1.py
+++ b/harvester/records/formats/gbl1.py
@@ -1,8 +1,7 @@
-"""harvester.harvest.records.gbl1"""
+"""harvester.records.formats.gbl1"""
 
 # ruff: noqa: N802
 
-import json
 from typing import Literal
 
 from attrs import define, field
@@ -12,10 +11,7 @@ from harvester.records.record import JSONSourceRecord
 
 @define
 class GBL1(JSONSourceRecord):
-    """GeoBlacklight1.x (GBL1) metadata format SourceRecord class.
-
-    NOTE: This source record class is only used for OGM harvests.
-    """
+    """GeoBlacklight1.x (GBL1) metadata format SourceRecord class."""
 
     metadata_format: Literal["gbl1"] = field(default="gbl1")
 
@@ -48,74 +44,6 @@ class GBL1(JSONSourceRecord):
 
     def _locn_geometry(self) -> str | None:
         return self._dcat_bbox()
-
-    def _dct_references_s_ogm(self) -> dict:
-        """Field method helper: "dct_references_s"
-
-        For most OGM repositories providing GBL1 metadata, pulling this URL from the
-        dct_references_s field directly suffices, and this approach is therefore the
-        default.  However, some repositories require alternate strategies which can be
-        optionally defined in the OGM config YAML using the "external_url_strategy"
-        property.
-
-        Additionally, if the URI "http://schema.org/downloadUrl" is present, and only a
-        single value, use.  If value is array, skip, as we cannot be sure of a single
-        download link to choose from.
-        """
-        # extract required external url
-        url: None | str
-        if external_url_strategy := self.ogm_repo_config.get("external_url_strategy"):
-            url = self._use_external_url_strategy(external_url_strategy)
-        else:
-            refs_dict = json.loads(self.parsed_data["dct_references_s"])
-            url = refs_dict.get("http://schema.org/url")
-        if not url:
-            error_message = "Could not determine external URL from source metadata"
-            raise ValueError(error_message)
-        urls_dict = {"http://schema.org/url": url}
-
-        # extract optional download url
-        download_uri = "http://schema.org/downloadUrl"
-        refs_dict = json.loads(self.parsed_data["dct_references_s"])
-        if download_value := refs_dict.get(download_uri):  # noqa: SIM102
-            if isinstance(download_value, str):
-                urls_dict[download_uri] = [  # type: ignore[assignment]
-                    {
-                        "label": "Data",
-                        "url": download_value,
-                    }
-                ]
-
-        return urls_dict
-
-    def _use_external_url_strategy(self, alternate_strategy: dict) -> str:
-        """Apply alternative strategy for extracting external URL from source record.
-
-        OGM repositories may include an optional "external_url_strategy" property where
-        a sub-property "name" defines the strategy to use.  Currently supported:
-
-            - "base_url_and_slug": a pre-defined base URL is combined with the value from
-            a defined field to construct a URL
-
-            - "field_value": a single field contains a full URL
-        """
-        url: None | str
-        strategy_name = alternate_strategy["name"]
-        if strategy_name == "base_url_and_slug":
-            url = "/".join(
-                [
-                    alternate_strategy["base_url"],
-                    self.parsed_data[alternate_strategy["gbl1_field"]],
-                ]
-            )
-        elif strategy_name == "field_value":
-            url = self.parsed_data.get(alternate_strategy["gbl1_field"])
-            if url and not url.startswith("http"):
-                url = None
-        else:
-            error_message = f"Alternate URL strategy not recognized: {strategy_name}"
-            raise ValueError(error_message)
-        return url
 
     ##########################
     # Optional Field Methods

--- a/harvester/records/formats/gbl1.py
+++ b/harvester/records/formats/gbl1.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from attrs import define, field
 
+from harvester.records.formats.helpers import gbl_resource_class_value_map
 from harvester.records.record import JSONSourceRecord
 
 
@@ -33,9 +34,7 @@ class GBL1(JSONSourceRecord):
 
     def _gbl_resourceClass_sm(self) -> list[str]:
         if value := self.parsed_data.get("dc_type_s"):  # noqa: SIM102s
-            if mapped_value := self.gbl_resource_class_value_map.get(
-                value.strip().lower()
-            ):
+            if mapped_value := gbl_resource_class_value_map().get(value.strip().lower()):
                 return [mapped_value]
         return ["Other"]
 

--- a/harvester/records/formats/helpers.py
+++ b/harvester/records/formats/helpers.py
@@ -1,0 +1,33 @@
+"""harvester.records.helpers"""
+
+
+def gbl_resource_class_value_map() -> dict:
+    """Map values to controlled gbl_resourceClass_sm values for GBL1 and Aardvark.
+
+    https://opengeometadata.org/ogm-aardvark/#resource-class-values
+    """
+    return {
+        "attribute": None,
+        "attributeType": None,
+        "collectionHardware": None,
+        "collectionSession": None,
+        "collections": "Collections",
+        "dataset": "Datasets",
+        "datasets": "Datasets",
+        "dimensionGroup": None,
+        "feature": None,
+        "featureType": None,
+        "fieldSession": None,
+        "imagery": "Imagery",
+        "maps": "Maps",
+        "model": None,
+        "nonGeographicDataset": None,
+        "other": "Other",
+        "property": None,
+        "series": None,
+        "service": None,
+        "software": None,
+        "tile": None,
+        "web services": "Web services",
+        "websites": "Websites",
+    }

--- a/harvester/records/formats/iso19139.py
+++ b/harvester/records/formats/iso19139.py
@@ -1,4 +1,4 @@
-"""harvester.harvest.records.iso19139"""
+"""harvester.records.formats.iso19139"""
 
 # ruff: noqa: N802, N815; allows camelCase for aardvark fields
 # ruff: noqa: PERF401; preferring more explicit, non list comprehensions

--- a/harvester/records/formats/marc.py
+++ b/harvester/records/formats/marc.py
@@ -1,4 +1,4 @@
-"""harvester.harvest.records.marc"""
+"""harvester.records.formats.marc"""
 
 # ruff: noqa: N802
 

--- a/harvester/records/formats/marc.py
+++ b/harvester/records/formats/marc.py
@@ -6,11 +6,11 @@ from typing import Literal
 
 from attrs import define, field
 
-from harvester.records.record import XMLSourceRecord
+from harvester.records.record import MarcalyxSourceRecord
 
 
 @define
-class MARC(XMLSourceRecord):
+class MARC(MarcalyxSourceRecord):
     """MIT MARC metadata format SourceRecord class."""
 
     metadata_format: Literal["marc"] = field(default="marc")

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -553,35 +553,3 @@ class JSONSourceRecord(SourceRecord):
                 data = json.loads(data)
             self._parsed_data = data
         return self._parsed_data
-
-    @property
-    def gbl_resource_class_value_map(self) -> dict:
-        """Maps values to controlled gbl_resourceClass_sm values for GBL1 and Aardvark.
-
-        https://opengeometadata.org/ogm-aardvark/#resource-class-values
-        """
-        return {
-            "attribute": None,
-            "attributeType": None,
-            "collectionHardware": None,
-            "collectionSession": None,
-            "collections": "Collections",
-            "dataset": "Datasets",
-            "datasets": "Datasets",
-            "dimensionGroup": None,
-            "feature": None,
-            "featureType": None,
-            "fieldSession": None,
-            "imagery": "Imagery",
-            "maps": "Maps",
-            "model": None,
-            "nonGeographicDataset": None,
-            "other": "Other",
-            "property": None,
-            "series": None,
-            "service": None,
-            "software": None,
-            "tile": None,
-            "web services": "Web services",
-            "websites": "Websites",
-        }

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -8,6 +8,7 @@ import logging
 from abc import abstractmethod
 from typing import Any, Literal
 
+import marcalyx  # type: ignore[import-untyped]
 from attrs import asdict, define, field, fields
 from attrs.validators import in_, instance_of
 from lxml import etree  # type: ignore[import-untyped]
@@ -461,7 +462,7 @@ class SourceRecord:
 
 @define
 class XMLSourceRecord(SourceRecord):
-    """Shared parent class for XML based FGDC and ISO19139 source record classes."""
+    """Parsed XML file type source records."""
 
     nsmap: dict = field(factory=dict)
     _root: etree._Element = field(default=None, repr=False)
@@ -530,7 +531,7 @@ class XMLSourceRecord(SourceRecord):
 
 @define
 class JSONSourceRecord(SourceRecord):
-    """Shared parent class for JSON based GBL1 and Aardvark source record classes."""
+    """Parsed JSON file type source records."""
 
     _parsed_data: dict = field(default=None)
 
@@ -553,3 +554,10 @@ class JSONSourceRecord(SourceRecord):
                 data = json.loads(data)
             self._parsed_data = data
         return self._parsed_data
+
+
+@define
+class MarcalyxSourceRecord(XMLSourceRecord):
+    """Parsed MARC XML file type source records."""
+
+    marc: marcalyx.Record = field(default=None)

--- a/harvester/records/sources/alma.py
+++ b/harvester/records/sources/alma.py
@@ -1,0 +1,40 @@
+"""harvester.records.sources.alma"""
+
+import logging
+from typing import Literal
+
+from attrs import define, field
+from marcalyx import Record as MARCRecord  # type: ignore[import-untyped]
+
+from harvester.config import Config
+from harvester.records import SourceRecord
+from harvester.records.formats import MARC
+
+logger = logging.getLogger(__name__)
+
+CONFIG = Config()
+
+
+@define(slots=False)
+class AlmaSourceRecord(SourceRecord):
+    """Class to extend SourceRecord for harvested Alma MARC XML records.
+
+    Extended Args:
+        ogm_repo_config: config dictionary of OGM repository from configuration YAML
+    """
+
+    origin: Literal["alma", "mit", "ogm"] = field(default="alma")
+
+    def _dct_references_s(self) -> str:
+        """Shared field method: dct_references_s"""
+        raise NotImplementedError
+
+    def _schema_provider_s(self) -> str:
+        """Shared field method: schema_provider_s"""
+        return "MIT Libraries"
+
+
+@define(slots=False)
+class AlmaMARC(AlmaSourceRecord, MARC):
+    metadata_format: Literal["marc"] = field(default="marc")
+    marc: MARCRecord = field(default=None)

--- a/harvester/records/sources/alma.py
+++ b/harvester/records/sources/alma.py
@@ -20,7 +20,7 @@ class AlmaSourceRecord(SourceRecord):
     """Class to extend SourceRecord for harvested Alma MARC XML records.
 
     Extended Args:
-        ogm_repo_config: config dictionary of OGM repository from configuration YAML
+        None at this time
     """
 
     origin: Literal["alma", "mit", "ogm"] = field(default="alma")

--- a/harvester/records/sources/alma.py
+++ b/harvester/records/sources/alma.py
@@ -23,7 +23,7 @@ class AlmaSourceRecord(SourceRecord):
         None at this time
     """
 
-    origin: Literal["alma", "mit", "ogm"] = field(default="alma")
+    origin: Literal["alma"] = field(default="alma")
 
     def _dct_references_s(self) -> str:
         """Shared field method: dct_references_s"""

--- a/harvester/records/sources/mit.py
+++ b/harvester/records/sources/mit.py
@@ -29,7 +29,7 @@ class MITSourceRecord(SourceRecord):
             after the record has been processed to manage the message in the queue
     """
 
-    origin: Literal["alma", "mit", "ogm"] = field(default="mit")
+    origin: Literal["mit"] = field(default="mit")
     zip_file_location: str = field(default=None)
     sqs_message: ZipFileEventMessage = field(default=None)
 

--- a/harvester/records/sources/mit.py
+++ b/harvester/records/sources/mit.py
@@ -1,0 +1,81 @@
+"""harvester.records.sources.mit"""
+
+import json
+import logging
+from typing import Literal
+
+from attrs import define, field
+
+from harvester.aws.sqs import ZipFileEventMessage
+from harvester.config import Config
+from harvester.records import SourceRecord
+from harvester.records.formats import FGDC, ISO19139
+
+logger = logging.getLogger(__name__)
+
+CONFIG = Config()
+
+
+@define(slots=False)
+class MITSourceRecord(SourceRecord):
+    """Class to extend SourceRecord for harvested GIS team Zip files.
+
+    Extended Args:
+        zip_file_location: path string to the zip file
+            - this may be local or S3 URI
+        sqs_message: ZipFileEventMessage instance
+            - present only for MIT harvests
+            - by affixing to SourceRecord during record retrieval, it allows for use
+            after the record has been processed to manage the message in the queue
+    """
+
+    origin: Literal["alma", "mit", "ogm"] = field(default="mit")
+    zip_file_location: str = field(default=None)
+    sqs_message: ZipFileEventMessage = field(default=None)
+
+    def _dct_references_s(self) -> str:
+        """Create dct_references_s JSON string for MIT harvests.
+
+        For MIT harvests, this includes the data zip file, source and normalized metadata
+        records in CDN, and a link to the TIMDEX item page.
+        """
+        cdn_folder = {True: "restricted", False: "public"}[self.is_restricted]
+        cdn_root = CONFIG.http_cdn_root
+        download_urls = [
+            {
+                "label": "Source Metadata",
+                "url": f"{cdn_root}/public/{self.source_metadata_filename}",
+            },
+            {
+                "label": "Aardvark Metadata",
+                "url": f"{cdn_root}/public/{self.normalized_metadata_filename}",
+            },
+            {
+                "label": "Data",
+                "url": f"{cdn_root}/{cdn_folder}/{self.identifier}.zip",
+            },
+        ]
+        website_url = (
+            "https://geodata.libraries.mit.edu/record/"
+            f"gismit:{self.identifier.removeprefix('mit:')}"
+        )
+        return json.dumps(
+            {
+                "http://schema.org/downloadUrl": download_urls,
+                "http://schema.org/url": website_url,
+            }
+        )
+
+    def _schema_provider_s(self) -> str:
+        """Shared field method: schema_provider_s"""
+        return "GIS Lab, MIT Libraries"
+
+
+@define(slots=False)
+class MITFGDC(MITSourceRecord, FGDC):
+    pass
+
+
+@define(slots=False)
+class MITISO19139(MITSourceRecord, ISO19139):
+    pass

--- a/harvester/records/sources/ogm.py
+++ b/harvester/records/sources/ogm.py
@@ -1,0 +1,151 @@
+"""harvester.records.sources.ogm"""
+
+import json
+import logging
+from typing import Literal
+
+from attrs import define, field
+
+from harvester.config import Config
+from harvester.records import SourceRecord
+from harvester.records.formats import FGDC, GBL1, ISO19139, Aardvark
+
+logger = logging.getLogger(__name__)
+
+CONFIG = Config()
+
+
+@define(slots=False)
+class OGMSourceRecord(SourceRecord):
+    """Class to extend SourceRecord for harvested OGM metadata records.
+
+    Extended Args:
+        ogm_repo_config: config dictionary of OGM repository from configuration YAML
+    """
+
+    origin: Literal["alma", "mit", "ogm"] = field(default="ogm")
+    ogm_repo_config: dict = field(default=None)
+
+    def _schema_provider_s(self) -> str:
+        """Shared field method: schema_provider_s"""
+        return self.ogm_repo_config["name"]
+
+
+@define(slots=False)
+class OGMFGDC(OGMSourceRecord, FGDC):
+    def _dct_references_s(self) -> str:
+        # Currently not harvesting FGDC from OGM, this would need defining if so
+        raise NotImplementedError
+
+
+@define(slots=False)
+class OGMISO19139(OGMSourceRecord, ISO19139):
+    def _dct_references_s(self) -> str:
+        # Currently not harvesting ISO19139 from OGM, this would need defining if so
+        raise NotImplementedError
+
+
+@define(slots=False)
+class OGMGBL1(OGMSourceRecord, GBL1):
+    def _dct_references_s(self) -> str:
+        """Field method helper: "dct_references_s"
+
+        For most OGM repositories providing GBL1 metadata, pulling this URL from the
+        dct_references_s field directly suffices, and this approach is therefore the
+        default.  However, some repositories require alternate strategies which can be
+        optionally defined in the OGM config YAML using the "external_url_strategy"
+        property.
+
+        Additionally, if the URI "http://schema.org/downloadUrl" is present, and only a
+        single value, use.  If value is array, skip, as we cannot be sure of a single
+        download link to choose from.
+        """
+        # extract required external url
+        url: None | str
+        if external_url_strategy := self.ogm_repo_config.get("external_url_strategy"):
+            url = self._use_external_url_strategy(external_url_strategy)
+        else:
+            refs_dict = json.loads(self.parsed_data["dct_references_s"])
+            url = refs_dict.get("http://schema.org/url")
+        if not url:
+            error_message = "Could not determine external URL from source metadata"
+            raise ValueError(error_message)
+        urls_dict = {"http://schema.org/url": url}
+
+        # extract optional download url
+        download_uri = "http://schema.org/downloadUrl"
+        refs_dict = json.loads(self.parsed_data["dct_references_s"])
+        if download_value := refs_dict.get(download_uri):  # noqa: SIM102
+            if isinstance(download_value, str):
+                urls_dict[download_uri] = [  # type: ignore[assignment]
+                    {
+                        "label": "Data",
+                        "url": download_value,
+                    }
+                ]
+
+        return json.dumps(urls_dict)
+
+    def _use_external_url_strategy(self, alternate_strategy: dict) -> str:
+        """Apply alternative strategy for extracting external URL from source record.
+
+        OGM repositories may include an optional "external_url_strategy" property where
+        a sub-property "name" defines the strategy to use.  Currently supported:
+
+            - "base_url_and_slug": a pre-defined base URL is combined with the value from
+            a defined field to construct a URL
+
+            - "field_value": a single field contains a full URL
+        """
+        url: None | str
+        strategy_name = alternate_strategy["name"]
+        if strategy_name == "base_url_and_slug":
+            url = "/".join(
+                [
+                    alternate_strategy["base_url"],
+                    self.parsed_data[alternate_strategy["gbl1_field"]],
+                ]
+            )
+        elif strategy_name == "field_value":
+            url = self.parsed_data.get(alternate_strategy["gbl1_field"])
+            if url and not url.startswith("http"):
+                url = None
+        else:
+            error_message = f"Alternate URL strategy not recognized: {strategy_name}"
+            raise ValueError(error_message)
+        return url
+
+
+@define(slots=False)
+class OGMAardvark(OGMSourceRecord, Aardvark):
+    def _dct_references_s(self) -> str:
+        """Field method helper: "dct_references_s"
+
+        For OGM repositories that provide Aardvark metadata, the most reliable location
+        to find an external URL is the 'http://schema.org/url' key in the dct_references_s
+        JSON payload.
+
+        If the URI "http://schema.org/downloadUrl" is present, and only a single value,
+        use.  If array, skip, as cannot be sure of a single download link to choose from.
+        """
+        refs_dict = json.loads(self.parsed_data["dct_references_s"])
+
+        # extract required external URL
+        url = refs_dict.get("http://schema.org/url")
+        if not url:
+            error_message = "Could not determine external URL from source metadata"
+            raise ValueError(error_message)
+        urls_dict = {"http://schema.org/url": url}
+
+        # extract optional download url
+        download_uri = "http://schema.org/downloadUrl"
+        if download_value := refs_dict.get(download_uri):  # noqa: SIM102
+            if isinstance(download_value, str):
+                urls_dict[download_uri] = [
+                    {
+                        "label": "Data",
+                        "url": download_value,
+                    }
+                ]
+
+        return json.dumps(urls_dict)

--- a/harvester/records/sources/ogm.py
+++ b/harvester/records/sources/ogm.py
@@ -23,7 +23,7 @@ class OGMSourceRecord(SourceRecord):
         ogm_repo_config: config dictionary of OGM repository from configuration YAML
     """
 
-    origin: Literal["alma", "mit", "ogm"] = field(default="ogm")
+    origin: Literal["ogm"] = field(default="ogm")
     ogm_repo_config: dict = field(default=None)
 
     def _schema_provider_s(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,15 +24,16 @@ from harvester.harvest.alma import MITAlmaHarvester
 from harvester.harvest.mit import MITHarvester
 from harvester.harvest.ogm import OGMHarvester, OGMRepository
 from harvester.records import (
-    FGDC,
-    GBL1,
-    ISO19139,
-    Aardvark,
     MITAardvark,
     Record,
     SourceRecord,
     XMLSourceRecord,
 )
+from harvester.records.formats import (
+    FGDC,
+    ISO19139,
+)
+from harvester.records.sources.ogm import OGMGBL1, OGMAardvark
 from harvester.records.validators import ValidateGeoshapeWKT
 
 
@@ -714,7 +715,7 @@ def mocked_ogm_harvester():
 @pytest.fixture
 def gbl1_all_fields():
     with open("tests/fixtures/records/gbl1/gbl1_all_fields.json", "rb") as f:
-        return GBL1(
+        return OGMGBL1(
             origin="ogm",
             identifier="abc123",
             data=f.read(),
@@ -729,7 +730,7 @@ def gbl1_all_fields():
 @pytest.fixture
 def aardvark_all_fields():
     with open("tests/fixtures/records/aardvark/aardvark_all_fields.json", "rb") as f:
-        return Aardvark(
+        return OGMAardvark(
             origin="ogm",
             identifier="abc123",
             data=f.read(),

--- a/tests/test_harvest/test_mit_harvester.py
+++ b/tests/test_harvest/test_mit_harvester.py
@@ -5,7 +5,7 @@ import pytest
 from freezegun import freeze_time
 
 from harvester.harvest.mit import MITHarvester
-from harvester.records import FGDC
+from harvester.records.formats import FGDC
 
 
 def test_mit_harvester_list_local_files_equals_one():

--- a/tests/test_records/test_fgdc.py
+++ b/tests/test_records/test_fgdc.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from dateutil.parser import ParserError
 
-from harvester.records import FGDC
+from harvester.records.formats import FGDC
 
 #################################
 # Required Fields
@@ -108,7 +108,7 @@ def test_fgdc_optional_dct_temporal_sm_bad_date_logs_error_and_continues(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.fgdc.date_parser",
+        "harvester.records.formats.fgdc.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert fgdc_source_record_all_fields._dct_temporal_sm() == []
@@ -124,7 +124,7 @@ def test_fgdc_optional_gbl_dateRange_drsim_bad_date_logs_error_and_continues(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.fgdc.date_parser",
+        "harvester.records.formats.fgdc.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert fgdc_source_record_all_fields._gbl_dateRange_drsim() == []
@@ -186,7 +186,7 @@ def test_fgdc_optional_dct_issued_s_date_parse_error(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.fgdc.date_parser",
+        "harvester.records.formats.fgdc.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert fgdc_source_record_all_fields._dct_issued_s() is None
@@ -202,7 +202,7 @@ def test_fgdc_optional_dct_language_sm_parse_error_log_continue(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.fgdc.convert_lang_code",
+        "harvester.records.formats.fgdc.convert_lang_code",
         side_effect=Exception("Parsing Error"),
     ):
         assert fgdc_source_record_all_fields._dct_language_sm() == []

--- a/tests/test_records/test_iso19139.py
+++ b/tests/test_records/test_iso19139.py
@@ -5,7 +5,7 @@ import pytest
 from dateutil.parser import ParserError
 from lxml.etree import Element
 
-from harvester.records import ISO19139
+from harvester.records.formats import ISO19139
 
 #################################
 # Required Fields
@@ -127,7 +127,7 @@ def test_iso19139_optional_dct_temporal_sm_bad_date_logs_error_and_continues(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.iso19139.date_parser",
+        "harvester.records.formats.iso19139.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert iso19139_source_record_all_fields._dct_temporal_sm() == []
@@ -143,7 +143,7 @@ def test_iso19139_optional_gbl_dateRange_drsim_bad_date_logs_error_and_continues
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.iso19139.date_parser",
+        "harvester.records.formats.iso19139.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert iso19139_source_record_all_fields._gbl_dateRange_drsim() == []
@@ -182,7 +182,7 @@ def test_iso19139_optional_dct_issued_s_date_parse_error(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.iso19139.date_parser",
+        "harvester.records.formats.iso19139.date_parser",
         side_effect=ParserError("Bad date here"),
     ):
         assert iso19139_source_record_all_fields._dct_issued_s() is None
@@ -198,7 +198,7 @@ def test_iso19139_optional_dct_language_sm_parse_error_log_continue(
 ):
     caplog.set_level("DEBUG")
     with patch(
-        "harvester.records.iso19139.convert_lang_code",
+        "harvester.records.formats.iso19139.convert_lang_code",
         side_effect=Exception("Parsing Error"),
     ):
         assert iso19139_source_record_all_fields._dct_language_sm() == []

--- a/tests/test_records/test_record.py
+++ b/tests/test_records/test_record.py
@@ -7,7 +7,7 @@ import pytest
 from freezegun import freeze_time
 from lxml import etree
 
-from harvester.records import JSONSourceRecord, MITAardvark, SourceRecord
+from harvester.records import JSONSourceRecord, MITAardvark
 from harvester.records.exceptions import FieldMethodError, JSONSchemaValidationError
 
 
@@ -282,22 +282,6 @@ def test_mitaardvark_record_optional_fields_jsonschema_validation_success(
 def test_source_record_is_deleted_property_reads_event(fgdc_source_record_all_fields):
     fgdc_source_record_all_fields.event = "deleted"
     assert fgdc_source_record_all_fields.is_deleted
-
-
-def test_ogm_record_not_defined_dct_references_s_ogm_raise_error():
-    record = SourceRecord(
-        data=b"Hello World",
-        identifier="abc123",
-        origin="ogm",
-        event="created",
-        metadata_format="gbl1",
-    )
-    with pytest.raises(
-        NotImplementedError,
-        match="Field method 'dct_references_s' must be overridden by format specific "
-        "classes for OGM harvests.",
-    ):
-        record._dct_references_s_ogm()
 
 
 def test_record_shared_field_method_schema_provider_s_ogm_success(


### PR DESCRIPTION
### Purpose and background context

With the introduction of Alma as a new **source** of records, and MARC as a new **format**, it exposed some pain points in the previous architecture around the `SourceRecord` class, source harvesters, and the metadata format classes.

The logic needed to derive a normalized MIT Aardvark file is a combination of where it came from (source) and the metadata format of the original record.  Previously, the abstractions of harvester, generic record, and metadata specific classes were a bit leaky in that generic record classes (e.g. `SourceRecord`) or metadata specific classes (e.g. `FGDC`) had logic or conditionals specific to the origin (e.g. MIT or OGM).

This refactor avoids that by encapsulating logic specific to a source (aka origin) and logic specific to a metadata format.  With those more narrowly focused, this refactor introduces a **composite** class (e.g. `MITFGDC` or `OGMGBL1`) that inherits from two classes, providing a combination of logic that is appropriate for that source + format.

How this was achieved:
* module `harvester.records.formats` created to hold pre-existing classes `FGDC`, `ISO19139`, `GBL1`, etc.
  * these classes are largely the same, but have any source specific logic removed
  * the "format" module/directory implies any logic should be completely source/origin agnostic
* module `harvester.records.sources` created to hold **new** classes `MITSourceRecord`, `OGMSourceRecord`, `OGMSourceRecord`
  * these classes define logic that is specific to source, but agnostic to the metadata format
* module `harvester.records.sources` also defines **composite** classes like `MITFGDC` or `OGMGBL1` (as examples) that extend both a source and format class, creating these final classes with the correct mixture of logic
* harvesters now explicitly select these composite classes for use during generation of records
  * e.g. [MITHarvester](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-f2bff5f0a7e8271e43dd9d38fd844af3b4141ede10e682f21ca2f0e5a247cb6bR370-R375)
  * e.g. [OGMHarvester](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-691ee6bab1bcc33b75cbe92fdb4c17cdf5e92c4de5e34779d729ac413bffec17L148-R153)
  * e.g. [AlmaHarvester](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-2e6b91e7e7f294d31aaf65ae9da8b0fdb4e602cfd1cad4e951ddcb8aa68e0bbbR209)

Some examples of improvements this refactoring provides:
  * [source specific method for `dct_references_s` removed from `GBL1` class](https://github.com/MITLibraries/geo-harvester/commit/e1a37d558dad9d7cfd37b16bb1153848bf17e77c#diff-cbbf850eb6dc7b64a73f22dea4838852e88616829f04403dddba03bb2970787fL52-L118)
    * this `GBL1` metadata format class should have been agnostic to source
  * properties only required by a particular source, removed from base `SourceRecord` class
    * e.g. `zip_file_location` [removed from generic `SourceRecord`](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-66e5d8bb00727a1bb00a0d51c23e9b7f292987b23b5e7c3775d0ad74e18f81b4L153-L154), and [refactored to `MITSourceRecord`](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-03bc8382c7160002ee0f96b328dd1a86cf1a91928ec8a6d1c29c266c15f904d9R33)
    * e.g. `ogm_repo_config` dictionary [removed from generic `SourceRecord`](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-66e5d8bb00727a1bb00a0d51c23e9b7f292987b23b5e7c3775d0ad74e18f81b4L160), and [refactored to `OGMSourceRecord`](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-40fa3881d76f5991a7e655db940a20e54a74d66714f8cee39315dd5c811860ddR27)
  * source specific conditional logic no longer needed in `SourceRecord`
    * e.g. [removal of property to return output file name extension, refactored to source classes](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-66e5d8bb00727a1bb00a0d51c23e9b7f292987b23b5e7c3775d0ad74e18f81b4L178-L185)
    * e.g. [removal of source `match` statement in favor of explicit `dct_references_s` methods in source specific classes](https://github.com/MITLibraries/geo-harvester/commit/e1a37d558dad9d7cfd37b16bb1153848bf17e77c#diff-66e5d8bb00727a1bb00a0d51c23e9b7f292987b23b5e7c3775d0ad74e18f81b4L416-L420)
  * composite classes provide a name, class hierarchy, and docstrings for a combination of source + format
    * [example of OGM + FGDC / ISO19139, which is not handled yet, but we can represent that now in code](https://github.com/MITLibraries/geo-harvester/commit/e1a37d558dad9d7cfd37b16bb1153848bf17e77c#diff-40fa3881d76f5991a7e655db940a20e54a74d66714f8cee39315dd5c811860ddR34-R45)

Ultimately, these changes provide a place to define logic that is **specific to source + metadata format** which was absent before.

### Supports new Alma MARC harvests

A concrete example in which this will help support Alma MARC harvests is setting the `dct_references_s` field.

Previously, there was conditional logic in the `SourceRecord` class for what the `origin` was, with additional methods to support the code path (e.g. `dct_references_s_mit`).

If we had continued down this path,
  * we'd have to add `alma` as a `match` condition
  * define a new method `dct_references_s_alma` to handle that logic

While this would have worked, now we can quite easily define the logic for `dct_references_s` directly on the `AlmaSourceRecord` class [here](https://github.com/MITLibraries/geo-harvester/pull/221/files#diff-5a03af9c36d5b7f0b5afb96d37c118492570bfa98561c5d4f861f4fb241fabfbR28-R30) (noting it's not actually defined yet). 

### How can a reviewer manually see the effects of these changes?

The inputs and outputs are the same, so it's a bit difficutl to see the changes that way.  But a little poking around in a python shell can reveal how the class hierarchy has changed a bit.

Start an ipython shell with `pipenv run ipython`:
```python
from harvester.records.sources.mit import MITFGDC

source_record = MITFGDC(identifier='abc123', data=b'<note>XML here</note>', event='created')

# source + format obvious from class
type(source_record)
# Out[8]: harvester.records.sources.mit.MITFGDC

# class hierarchy shows composition approach to defining normalization logic
display(source_record.__class__.__mro__)
"""
(harvester.records.sources.mit.MITFGDC,
 harvester.records.sources.mit.MITSourceRecord,
 harvester.records.formats.fgdc.FGDC,
 harvester.records.record.XMLSourceRecord,
 harvester.records.record.SourceRecord,
 object)
"""
```

Note the [MRO class hierarchy](https://www.python.org/download/releases/2.3/mro/), where both `MITSourceRecord` and `FGDC` are contributing to a composite `MITFGDC` class.

Additionally, note that some properties are defined by classes now and not passing strings around:
```python
# comes from MITSourceRecord.origin default value
source_record.origin
# Out[6]: 'mit'

# comes from FGDC.metadata_format default value
source_record.metadata_format
# Out[7]: 'fgdc'
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-227

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

