### PR TITLE
Required fields for MARC normalization

### DIFF
--- a/harvester/harvest/alma.py
+++ b/harvester/harvest/alma.py
@@ -4,7 +4,6 @@ import glob
 import logging
 import re
 from collections.abc import Iterator
-from typing import Literal, cast
 
 import smart_open  # type: ignore[import-untyped]
 from attrs import define, field
@@ -184,27 +183,9 @@ class MITAlmaHarvester(Harvester):
     def create_source_record_from_marc_record(
         self, marc_record: MARCRecord
     ) -> tuple[str, AlmaMARC]:
-        """Create MARC SourceRecord from parsed MARC record."""
-        # derive identifier from ControlField 001
-        try:
-            identifier = next(
-                item for item in marc_record.controlFields() if item.tag == "001"
-            ).value
-        except IndexError as exc:  # pragma: nocover
-            message = "Could not extract identifier from ControlField 001"
-            raise ValueError(message) from exc
-
-        # derive event from Leader 5th character
-        event: Literal["created", "deleted"] = cast(
-            Literal["created", "deleted"],
-            {
-                "a": "created",
-                "c": "created",
-                "d": "deleted",
-                "n": "created",
-                "p": "created",
-            }[marc_record.leader[5]],
-        )
+        """Create AlmaMARC source record from parsed MARC record."""
+        identifier = AlmaMARC.get_identifier_from_001(marc_record)
+        event = AlmaMARC.get_event_from_leader(marc_record)
 
         return identifier, AlmaMARC(
             identifier=identifier,

--- a/harvester/records/__init__.py
+++ b/harvester/records/__init__.py
@@ -3,6 +3,7 @@
 # ruff: noqa: I001,F401
 
 from harvester.records.record import (
+    MarcalyxSourceRecord,
     MITAardvark,
     Record,
     SourceRecord,

--- a/harvester/records/formats/marc.py
+++ b/harvester/records/formats/marc.py
@@ -2,16 +2,37 @@
 
 # ruff: noqa: N802
 
-from typing import Literal
+import logging
+import re
+from decimal import Decimal, getcontext
+from typing import Literal, TypeAlias
 
 from attrs import define, field
 
 from harvester.records.record import MarcalyxSourceRecord
 
+logger = logging.getLogger(__name__)
+
+
+# Coordinate string expected in format "hdddmmss" (hemisphere-degrees-minutes-seconds)
+#   - e.g. W1800000, E1800000, N0840000, N0840000
+#   - https://www.loc.gov/marc/bibliographic/bd034.html
+COORDINATE_STRING: TypeAlias = str
+
+# regular expression to extract hemisphere, degree, minutes, and seconds from a
+# coordinate string
+COORD_REGEX = re.compile(
+    r"""^(?P<hemisphere>[NSEW+-])?
+         (?P<degrees>\d{3}(\.\d*)?)
+         (?P<minutes>\d{2}(\.\d*)?)?
+         (?P<seconds>\d{2}(\.\d*)?)?""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 @define
 class MARC(MarcalyxSourceRecord):
-    """MIT MARC metadata format SourceRecord class."""
+    """MARC metadata format SourceRecord class."""
 
     metadata_format: Literal["marc"] = field(default="marc")
 
@@ -20,70 +41,197 @@ class MARC(MarcalyxSourceRecord):
     ##########################
 
     def _dct_accessRights_s(self) -> str:
-        raise NotImplementedError
+        """Field method dct_accessRights_s"""
+        return "Public"
 
     def _dct_title_s(self) -> str | None:
-        raise NotImplementedError
+        return self.marc.titleStatement().value.strip()
 
     def _gbl_resourceClass_sm(self) -> list[str]:
-        raise NotImplementedError
+        """Field method: gbl_resourceClass_sm
+
+        Controlled vocabulary:
+            - 'Datasets'
+            - 'Maps'
+            - 'Imagery'
+            - 'Collections'
+            - 'Websites'
+            - 'Web services'
+            - 'Other'
+        """
+        return ["Maps"]
 
     def _dcat_bbox(self) -> str | None:
-        raise NotImplementedError
+        """Field method: dcat_bbox"""
+        bbox_data = self._get_largest_bounding_box()
+        if bbox_data is None:
+            return None
+
+        return (
+            f"ENVELOPE({bbox_data['w']}, "
+            f"{bbox_data['e']}, "
+            f"{bbox_data['n']}, "
+            f"{bbox_data['s']})"
+        )
 
     def _locn_geometry(self) -> str | None:
-        raise NotImplementedError
+        """Field method: locn_geometry
+
+        Some MARC records have a set of coordinates in 034 where the E/W and N/S
+        coordinates are the same, effectively defining a WKT POINT.  If this is true
+        across even multiple 034 tags, return a WKT POINT for this field.
+        """
+        bbox_data = self._get_largest_bounding_box()
+        if bbox_data is None:
+            return None
+
+        if bbox_data["w"] == bbox_data["e"] and bbox_data["n"] == bbox_data["s"]:
+            return f"POINT({bbox_data['w']}, {bbox_data['n']})"
+
+        return self._dcat_bbox()
 
     ##########################
     # Optional Field Methods
     ##########################
 
     def _dct_description_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _dcat_keyword_sm(self) -> list[str]:
         """New field in Aardvark: no mapping from GBL1 to dcat_keyword_sm."""
-        raise NotImplementedError
+        return []
 
     def _dct_alternative_sm(self) -> list[str]:
         """New field in Aardvark: no mapping from GBL1 to dct_alternative_sm."""
-        raise NotImplementedError
+        return []
 
     def _dct_creator_sm(self) -> list[str] | None:
-        raise NotImplementedError
+        return None
 
     def _dct_format_s(self) -> str | None:
-        raise NotImplementedError
+        return None
 
     def _dct_issued_s(self) -> str | None:
-        raise NotImplementedError
+        return None
 
     def _dct_identifier_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _dct_language_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _dct_publisher_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _dct_rights_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _dct_spatial_sm(self) -> list[str] | None:
-        raise NotImplementedError
+        return None
 
     def _dct_subject_sm(self) -> list[str] | None:
-        raise NotImplementedError
+        return None
 
     def _dct_temporal_sm(self) -> list[str] | None:
-        raise NotImplementedError
+        return None
 
     def _gbl_dateRange_drsim(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _gbl_resourceType_sm(self) -> list[str]:
-        raise NotImplementedError
+        return []
 
     def _gbl_indexYear_im(self) -> list[int]:
-        raise NotImplementedError
+        return []
+
+    ##########################
+    # Helpers
+    ##########################
+
+    def _get_largest_bounding_box(
+        self,
+    ) -> dict[Literal["w", "e", "n", "s"], Decimal] | None:
+        """Method to return largest bounding box from 034 tags.
+
+        Subfield mapping:
+            $d - Coordinates - westernmost longitude (NR)
+            $e - Coordinates - easternmost longitude (NR)
+            $f - Coordinates - northernmost latitude (NR)
+            $g - Coordinates - southernmost latitude (NR)
+        """
+        subfield_to_direction = {"d": "w", "e": "e", "f": "n", "g": "s"}
+
+        # parse and filter 034 tags
+        tags = self.marc.field("034")
+        tags = [
+            tag
+            for tag in tags
+            if all(tag.subfield(subfield) for subfield in subfield_to_direction)
+        ]
+        if not tags:
+            message = "Record does not have valid 034 tag(s), cannot determine bbox."
+            logger.debug(message)
+            return None
+
+        # build dictionary of all corner values
+        bbox_data: dict[str, list] = {
+            direction: [] for direction in subfield_to_direction.values()
+        }
+        for tag in tags:
+            for subfield, direction in subfield_to_direction.items():
+                value = self.convert_coordinate_string_to_decimal(
+                    tag.subfield(subfield)[0].value
+                )
+                if value is not None:
+                    bbox_data[direction].append(value)
+
+        # return None if any four corners do not have values
+        if not all(bbox_data.values()):
+            return None
+
+        # return largest box
+        return {
+            "w": min(bbox_data["w"]),
+            "e": max(bbox_data["e"]),
+            "n": max(bbox_data["n"]),
+            "s": min(bbox_data["s"]),
+        }
+
+    @classmethod
+    def pad_coordinate_string(cls, coordinate_string: COORDINATE_STRING) -> str:
+        """Pad coordinate string with zeros."""
+        hemisphere, coordinate = coordinate_string[0], coordinate_string[1:]
+        if hemisphere in "NSEW":
+            coordinate = f"{coordinate:>07}"
+        return hemisphere + coordinate
+
+    @classmethod
+    def convert_coordinate_string_to_decimal(
+        cls,
+        coordinate_string: COORDINATE_STRING,
+        precision: int = 10,
+    ) -> Decimal | None:
+        """Convert string coordinate to 10 digit precision decimal."""
+        # get original global decimal precision and set temporarily
+        original_precision = getcontext().prec
+        getcontext().prec = precision
+
+        # extract coordinate parts
+        matches = COORD_REGEX.search(cls.pad_coordinate_string(coordinate_string))
+        if not matches:
+            return None
+        parts = matches.groupdict()
+
+        # construct decimal
+        dec = (
+            Decimal(parts.get("degrees"))  # type: ignore[arg-type]
+            + Decimal(parts.get("minutes") or 0) / 60
+            + Decimal(parts.get("seconds") or 0) / 3600
+        )
+        if parts.get("hemisphere") and parts["hemisphere"].lower() in "ws-":
+            dec = dec * -1
+
+        # reset global decimal precision
+        getcontext().prec = original_precision
+
+        return dec

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -12,6 +12,7 @@ import marcalyx  # type: ignore[import-untyped]
 from attrs import asdict, define, field, fields
 from attrs.validators import in_, instance_of
 from lxml import etree  # type: ignore[import-untyped]
+from marcalyx.marcalyx import DataField, SubField  # type: ignore[import-untyped]
 
 from harvester.config import Config
 from harvester.records.controlled_terms import (
@@ -595,12 +596,23 @@ class MarcalyxSourceRecord(XMLSourceRecord):
             marc_record_element = etree.fromstring(self.data)
             self.marc = marcalyx.Record(marc_record_element)
 
-    def get_single_tag(self, tag: str) -> marcalyx.DataField | None:
+    def get_single_tag(self, tag: str) -> DataField | None:
         """Return a single tag if only one instance of that tag number exists."""
         tags = self.marc.field(tag)
         if len(tags) == 1:
             return tags[0]
         if len(tags) > 1:
             message = f"Multiple tags found in MARC record for tag: {tag}"
+            raise ValueError(message)
+        return None
+
+    @staticmethod
+    def get_single_subfield(tag: DataField, subfield: str) -> SubField | None:
+        """Return a single subfield if only one instance of that subfield exists."""
+        subfields = tag.subfield(subfield)
+        if len(subfields) == 1:
+            return subfields[0]
+        if len(subfields) > 1:
+            message = f"Multiple subfields found in tag for subfield: {subfield}"
             raise ValueError(message)
         return None

--- a/harvester/records/sources/alma.py
+++ b/harvester/records/sources/alma.py
@@ -1,7 +1,8 @@
 """harvester.records.sources.alma"""
 
+import json
 import logging
-from typing import Literal
+from typing import Literal, cast
 
 from attrs import define, field
 from marcalyx import Record as MARCRecord  # type: ignore[import-untyped]
@@ -25,16 +26,48 @@ class AlmaSourceRecord(SourceRecord):
 
     origin: Literal["alma"] = field(default="alma")
 
-    def _dct_references_s(self) -> str:
-        """Shared field method: dct_references_s"""
-        raise NotImplementedError
-
     def _schema_provider_s(self) -> str:
         """Shared field method: schema_provider_s"""
-        return "MIT Libraries"
+        return "MIT Libraries"  # pragma: nocover
 
 
 @define(slots=False)
 class AlmaMARC(AlmaSourceRecord, MARC):
     metadata_format: Literal["marc"] = field(default="marc")
-    marc: MARCRecord = field(default=None)
+
+    @staticmethod
+    def get_identifier_from_001(marc_record: MARCRecord) -> str:
+        """Static method to extract identifier from 001 tag."""
+        try:
+            identifier = next(
+                item for item in marc_record.controlFields() if item.tag == "001"
+            ).value
+        except IndexError as exc:  # pragma: nocover
+            message = "Could not extract identifier from ControlField 001"
+            raise ValueError(message) from exc
+        return identifier
+
+    @staticmethod
+    def get_event_from_leader(marc_record: MARCRecord) -> Literal["created", "deleted"]:
+        """Static method to determine a harvest event from leader."""
+        return cast(
+            Literal["created", "deleted"],
+            {
+                "a": "created",
+                "c": "created",
+                "d": "deleted",
+                "n": "created",
+                "p": "created",
+            }[marc_record.leader[5]],
+        )
+
+    def _dct_references_s(self) -> str:
+        """Shared field method: dct_references_s.
+
+        The primary URL returned is the Primo item page.
+        """
+        primo_url = (
+            "https://mit.primo.exlibrisgroup.com/permalink/01MIT_INST/jp08pj/alma"
+            + self.get_identifier_from_001(self.marc)
+        )
+        return json.dumps({"http://schema.org/url": primo_url})

--- a/harvester/records/sources/mit.py
+++ b/harvester/records/sources/mit.py
@@ -68,7 +68,7 @@ class MITSourceRecord(SourceRecord):
 
     def _schema_provider_s(self) -> str:
         """Shared field method: schema_provider_s"""
-        return "GIS Lab, MIT Libraries"
+        return "GIS Lab, MIT Libraries"  # pragma: nocover
 
 
 @define(slots=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from harvester.records.formats import (
     FGDC,
     ISO19139,
 )
+from harvester.records.sources.alma import AlmaMARC
 from harvester.records.sources.ogm import OGMGBL1, OGMAardvark
 from harvester.records.validators import ValidateGeoshapeWKT
 
@@ -792,4 +793,60 @@ def aardvark_empty_strings():
                 "name": "Earth",
                 "metadata_format": "aardvark",
             },
+        )
+
+
+@pytest.fixture
+def almamarc_source_record():
+    with open("tests/fixtures/alma/single_records/geospatial_valid.xml", "rb") as f:
+        return AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
+        )
+
+
+@pytest.fixture
+def almamarc_source_record_missing_subfield_034():
+    with open(
+        "tests/fixtures/alma/single_records/geospatial_missing_subfield_034.xml", "rb"
+    ) as f:
+        return AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
+        )
+
+
+@pytest.fixture
+def almamarc_source_record_missing_034():
+    with open("tests/fixtures/alma/single_records/geospatial_missing_034.xml", "rb") as f:
+        return AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
+        )
+
+
+@pytest.fixture
+def almamarc_source_record_invalid_subfield_034():
+    with open(
+        "tests/fixtures/alma/single_records/geospatial_invalid_subfield_034.xml", "rb"
+    ) as f:
+        return AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
+        )
+
+
+@pytest.fixture
+def almamarc_source_record_multiple_034():
+    with open(
+        "tests/fixtures/alma/single_records/geospatial_multiple_034.xml", "rb"
+    ) as f:
+        return AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
         )

--- a/tests/fixtures/alma/single_records/geospatial_invalid_subfield_034.xml
+++ b/tests/fixtures/alma/single_records/geospatial_invalid_subfield_034.xml
@@ -1,0 +1,244 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">IAMNOTVALID</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_missing_034.xml
+++ b/tests/fixtures/alma/single_records/geospatial_missing_034.xml
@@ -1,0 +1,237 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_missing_subfield_034.xml
+++ b/tests/fixtures/alma/single_records/geospatial_missing_subfield_034.xml
@@ -1,0 +1,244 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <!-- missing subfield $g -->
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/fixtures/alma/single_records/geospatial_multiple_034.xml
+++ b/tests/fixtures/alma/single_records/geospatial_multiple_034.xml
@@ -1,0 +1,251 @@
+<record>
+    <leader>02642cem 2200637 a 4500</leader>
+    <controlfield tag="005">20231211171314.0</controlfield>
+    <controlfield tag="007">aj canzn</controlfield>
+    <controlfield tag="008">800506s1979 enk a 0 eng</controlfield>
+    <controlfield tag="001">990022897960106761</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+        <subfield code="a">80692167</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">0906358019</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0503300</subfield>
+        <subfield code="e">E0503300</subfield>
+        <subfield code="f">N0260139</subfield>
+        <subfield code="g">N0260139</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+        <subfield code="a">a</subfield>
+        <subfield code="d">E0403300</subfield>
+        <subfield code="e">E0403300</subfield>
+        <subfield code="f">N0160139</subfield>
+        <subfield code="g">N0160139</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(MCM)002289796MIT01</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+        <subfield code="a">(OCoLC)06533196</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+        <subfield code="a">DLC</subfield>
+        <subfield code="b">eng</subfield>
+        <subfield code="c">DLC</subfield>
+        <subfield code="d">OCL</subfield>
+        <subfield code="d">OCLCQ</subfield>
+        <subfield code="d">OCLCO</subfield>
+        <subfield code="d">OCLCA</subfield>
+        <subfield code="d">OCLCF</subfield>
+        <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+        <subfield code="a">a-ba---</subfield>
+    </datafield>
+    <datafield tag="049" ind1=" " ind2=" ">
+        <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+        <subfield code="a">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7590</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+        <subfield code="a">7594</subfield>
+        <subfield code="b">M3</subfield>
+    </datafield>
+    <datafield tag="110" ind1="2" ind2=" ">
+        <subfield code="a">Fairey Surveys Ltd.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="h">[cartographic material] /</subfield>
+        <subfield code="c">map &amp; town plans produced by Fairey Surveys Limited.
+        </subfield>
+    </datafield>
+    <datafield tag="255" ind1=" " ind2=" ">
+        <subfield code="a">Scales vary</subfield>
+        <subfield code="c">(E 50°33'00ʺ-E 50°33'00ʺ/N 26°01'39ʺ-N 26°01'39ʺ).
+        </subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire :</subfield>
+        <subfield code="b">Fairey,</subfield>
+        <subfield code="c">[1979?]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+        <subfield code="a">5 maps :</subfield>
+        <subfield code="b">both sides, col. ;</subfield>
+        <subfield code="c">on sheet 63 x 96 cm. folded to 21 x 12 cm. in cover 22 x 15
+            cm.
+        </subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+        <subfield code="a">cartographic image</subfield>
+        <subfield code="b">cri</subfield>
+        <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+        <subfield code="a">unmediated</subfield>
+        <subfield code="b">n</subfield>
+        <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+        <subfield code="a">sheet</subfield>
+        <subfield code="b">nb</subfield>
+        <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+        <subfield code="a">Fairey/Falcon map series</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Cover title: Bahrain, the businessman's map &amp; guide.
+        </subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Printed on both sides of sheet.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Includes advertisements, index, and 2 insets.</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+        <subfield code="a">Accompanied by text booklet: The businessman's guide, a
+            handy reference source for the visitor to Bahrain / designed, edited &amp;
+            published by Falcon Publishing, Manama, Bahrain and Parrish Rogers
+            International Ltd., London, Eng. (40 p. ; 22 cm.).
+        </subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+        <subfield code="a">1. Bahrain Island -- 2. Northern Bahrain -- 3. Al Muharraq
+            -- 4. Al Jufayr -- Al Manamah.
+        </subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+        <subfield code="a">Bahrain.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Bahrain</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+        <subfield code="a">Manama (Bahrain)</subfield>
+        <subfield code="v">Maps.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Road maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Tourist maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+        <subfield code="a">Maps.</subfield>
+        <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Falcon Publishing.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+        <subfield code="a">Parrish Rogers International Ltd.</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+        <subfield code="a">Fairey/Falcon map series.</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">mjy140828</subfield>
+        <subfield code="b">copy</subfield>
+        <subfield code="c">~</subfield>
+        <subfield code="e">wall</subfield>
+        <subfield code="j">e</subfield>
+        <subfield code="k">m</subfield>
+        <subfield code="l">blank</subfield>
+        <subfield code="m">blank</subfield>
+        <subfield code="o">a</subfield>
+        <subfield code="p">DLC</subfield>
+        <subfield code="q">r-map</subfield>
+        <subfield code="r">a</subfield>
+        <subfield code="s">1</subfield>
+        <subfield code="w">~</subfield>
+        <subfield code="x">0</subfield>
+        <subfield code="y">~</subfield>
+        <subfield code="z">~</subfield>
+        <subfield code="i">mjy</subfield>
+        <subfield code="d">140828</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT221103</subfield>
+    </datafield>
+    <datafield tag="910" ind1=" " ind2=" ">
+        <subfield code="a">MARCIVEAUT231209</subfield>
+    </datafield>
+    <datafield tag="949" ind1=" " ind2="0">
+        <subfield code="4">IP</subfield>
+        <subfield code="a">r-map</subfield>
+        <subfield code="b">RTC</subfield>
+        <subfield code="c">MAPRM</subfield>
+        <subfield code="k">MAP</subfield>
+        <subfield code="o">0</subfield>
+        <subfield code="p">39080036498050</subfield>
+        <subfield code="x">04</subfield>
+        <subfield code="h">G7590 1979.F3</subfield>
+    </datafield>
+    <datafield tag="961" ind1=" " ind2=" ">
+        <subfield code="a">Maidenhead, Berkshire : Fairey,</subfield>
+        <subfield code="a">1979</subfield>
+        <subfield code="a">enk</subfield>
+    </datafield>
+    <datafield tag="969" ind1=" " ind2=" ">
+        <subfield code="a">G7590 1979.F3</subfield>
+        <subfield code="a">06533196</subfield>
+        <subfield code="a">80692167</subfield>
+        <subfield code="a">0906358019</subfield>
+        <subfield code="a">9780906358016</subfield>
+    </datafield>
+    <datafield tag="990" ind1=" " ind2=" ">
+        <subfield code="a">MIT Rotch Library copy of map without text booklet.
+        </subfield>
+    </datafield>
+    <datafield tag="994" ind1=" " ind2=" ">
+        <subfield code="a">02</subfield>
+        <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield tag="900" ind1="0" ind2=" ">
+        <subfield code="b">RTC</subfield>
+        <subfield code="d">MAPRM</subfield>
+        <subfield code="f">G7590 1979.F3</subfield>
+        <subfield code="8">22467461200006761</subfield>
+    </datafield>
+    <datafield tag="985" ind1=" " ind2=" ">
+        <subfield code="j">0</subfield>
+        <subfield code="aa">MAPRM</subfield>
+        <subfield code="t">BOOK</subfield>
+        <subfield code="s">39080036498050</subfield>
+        <subfield code="a">23467461190006761</subfield>
+        <subfield code="c">04</subfield>
+        <subfield code="bb">MAP G7590 1979.F3</subfield>
+        <subfield code="i">RTC</subfield>
+    </datafield>
+</record>

--- a/tests/test_records/test_marc.py
+++ b/tests/test_records/test_marc.py
@@ -1,0 +1,110 @@
+"""tests.test_records.test_marc"""
+
+# ruff: noqa: N802, SLF001
+
+from decimal import Decimal
+
+from harvester.records.formats.marc import MARC
+
+BAD_COORDINATE_STRING = "X999"
+
+
+def test_marc_helper_pad_coordinate_string():
+    assert MARC.pad_coordinate_string(BAD_COORDINATE_STRING) == BAD_COORDINATE_STRING
+    assert MARC.pad_coordinate_string("E123") == "E0000123"
+    assert MARC.pad_coordinate_string("E1234567") == "E1234567"
+
+
+def test_marc_helper_convert_coordinate_string_to_decimal():
+    assert MARC.convert_coordinate_string_to_decimal("E0503300") == Decimal("50.55")
+    assert MARC.convert_coordinate_string_to_decimal("W0503300") == Decimal("-50.55")
+    assert MARC.convert_coordinate_string_to_decimal("N0260139") == Decimal("26.02750000")
+    assert MARC.convert_coordinate_string_to_decimal(BAD_COORDINATE_STRING) is None
+
+
+#################################
+# Required Fields
+#################################
+
+
+def test_marc_record_required_dct_accessRights_s(almamarc_source_record):
+    assert almamarc_source_record._dct_accessRights_s() == "Public"
+
+
+def test_marc_record_required_dct_title_s(almamarc_source_record):
+    assert (
+        almamarc_source_record._dct_title_s()
+        == "Bahrain [cartographic material] / map & town plans produced by Fairey "
+        "Surveys Limited."
+    )
+
+
+def test_marc_record_required_gbl_resourceClass_sm(almamarc_source_record):
+    assert almamarc_source_record._gbl_resourceClass_sm() == ["Maps"]
+
+
+def test_marc_record_required_dcat_bbox(almamarc_source_record):
+    assert (
+        almamarc_source_record._dcat_bbox()
+        == "ENVELOPE(50.55, 50.55, 26.02750000, 26.02750000)"
+    )
+
+
+def test_marc_record_required_dcat_bbox_missing_034(
+    caplog, almamarc_source_record_missing_034
+):
+    caplog.set_level("DEBUG")
+    assert almamarc_source_record_missing_034._dcat_bbox() is None
+    assert "Record does not have valid 034 tag(s), cannot determine bbox." in caplog.text
+
+
+def test_marc_record_required_dcat_bbox_multiple_034(
+    caplog, almamarc_source_record_multiple_034
+):
+    caplog.set_level("DEBUG")
+    assert (
+        almamarc_source_record_multiple_034._dcat_bbox()
+        == "ENVELOPE(40.55, 50.55, 26.02750000, 16.02750000)"
+    )
+
+
+def test_marc_record_required_locn_geometry_bbox(almamarc_source_record_multiple_034):
+    assert (
+        almamarc_source_record_multiple_034._locn_geometry()
+        == "ENVELOPE(40.55, 50.55, 26.02750000, 16.02750000)"
+    )
+
+
+def test_marc_record_required_locn_geometry_point(almamarc_source_record):
+    assert almamarc_source_record._locn_geometry() == "POINT(50.55, 26.02750000)"
+
+
+def test_marc_record_required_locn_geometry_missing_034(
+    caplog, almamarc_source_record_missing_034
+):
+    caplog.set_level("DEBUG")
+    assert almamarc_source_record_missing_034._locn_geometry() is None
+    assert "Record does not have valid 034 tag(s), cannot determine bbox." in caplog.text
+
+
+#################################
+# Optional Fields
+#################################
+
+
+#################################
+# Helpers
+#################################
+def test_marc_record_required_get_bounding_box_missing_subfield_return_none(
+    caplog, almamarc_source_record_missing_subfield_034
+):
+    caplog.set_level("DEBUG")
+    assert almamarc_source_record_missing_subfield_034._get_largest_bounding_box() is None
+    assert "Record does not have valid 034 tag(s), cannot determine bbox." in caplog.text
+
+
+def test_marc_record_required_get_bounding_box_invalid_subfield_return_none(
+    caplog, almamarc_source_record_invalid_subfield_034
+):
+    caplog.set_level("DEBUG")
+    assert almamarc_source_record_invalid_subfield_034._get_largest_bounding_box() is None

--- a/tests/test_records/test_marcalyx_record.py
+++ b/tests/test_records/test_marcalyx_record.py
@@ -1,0 +1,31 @@
+"""tests.test_records.test_marcalyx_record"""
+
+import pytest
+from marcalyx.marcalyx import DataField
+
+from harvester.records.sources.alma import AlmaMARC
+
+
+def test_marcalyx_record_marc_property_parsed_on_init_from_data_alone():
+    with open("tests/fixtures/alma/single_records/geospatial_valid.xml", "rb") as f:
+        source_record = AlmaMARC(
+            identifier="abc123",
+            data=f.read(),
+            event="created",
+        )
+    assert source_record.marc is not None
+
+
+def test_marcalyx_record_get_single_tag_success(almamarc_source_record):
+    assert isinstance(almamarc_source_record.get_single_tag("245"), DataField)
+
+
+def test_marcalyx_record_get_single_tag_none_found(almamarc_source_record):
+    assert almamarc_source_record.get_single_tag("1000") is None
+
+
+def test_marcalyx_record_get_single_tag_multiple_error(almamarc_source_record):
+    with pytest.raises(
+        ValueError, match="Multiple tags found in MARC record for tag: 655"
+    ):
+        almamarc_source_record.get_single_tag("655")

--- a/tests/test_records/test_marcalyx_record.py
+++ b/tests/test_records/test_marcalyx_record.py
@@ -1,7 +1,7 @@
 """tests.test_records.test_marcalyx_record"""
 
 import pytest
-from marcalyx.marcalyx import DataField
+from marcalyx.marcalyx import DataField, SubField
 
 from harvester.records.sources.alma import AlmaMARC
 
@@ -29,3 +29,21 @@ def test_marcalyx_record_get_single_tag_multiple_error(almamarc_source_record):
         ValueError, match="Multiple tags found in MARC record for tag: 655"
     ):
         almamarc_source_record.get_single_tag("655")
+
+
+def test_marcalyx_record_get_single_subfield_success(almamarc_source_record):
+    tag = almamarc_source_record.get_single_tag("245")
+    assert isinstance(almamarc_source_record.get_single_subfield(tag, "a"), SubField)
+
+
+def test_marcalyx_record_get_single_subfield_none_found(almamarc_source_record):
+    tag = almamarc_source_record.get_single_tag("245")
+    assert almamarc_source_record.get_single_subfield(tag, "x") is None
+
+
+def test_marcalyx_record_get_single_subfield_multiple_error(almamarc_source_record):
+    tag = almamarc_source_record.get_single_tag("969")
+    with pytest.raises(
+        ValueError, match="Multiple subfields found in tag for subfield: a"
+    ):
+        almamarc_source_record.get_single_subfield(tag, "a")


### PR DESCRIPTION
### Purpose and background context

This PR establishes structure, helpers, and field methods to support normalization of `MARC` to `MITAardvark` for required fields only.  With this functionality in place, `MARC` is able to normalize to valid `MITAardvark` records, sans optional fields which will follow.

It's likely that these required fields may slightly shift during work on optional fields, or more is learned from stakeholders, but this PR establishes a reasonable baseline to work from.

### How can a reviewer manually see the effects of these changes?

Future PRs will introduce an alma harvest CLI command so at this point still most readily checkable via Ipython shell.

Start shell:
```shell
pipenv run ipython
```

Normalize a single record:
```python
from harvester.records.sources.alma import AlmaMARC

# init AlmaMARC instance
with open("tests/fixtures/alma/single_records/geospatial_valid.xml","rb") as f:
    source_record = AlmaMARC(
        identifier="abc123",
        data=f.read(),
        event="created"
    )

# demonstrate AlmaMARC method that assists harvester
source_record.get_identifier_from_001(source_record.marc)
source_record.identifier = source_record.get_identifier_from_001(source_record.marc)
# Out[2]: '990022897960106761'

# normalize to MITAardvark
display(normalized_record.to_dict())
"""
{'dct_accessRights_s': 'Public',
 'dct_title_s': 'Bahrain [cartographic material] / map & town plans produced by Fairey Surveys Limited.',
 'gbl_mdModified_dt': '2024-03-21T19:08:00+00:00',
 'gbl_mdVersion_s': 'Aardvark',
 'gbl_resourceClass_sm': ['Maps'],
 'id': 'alma:990022897960106761',
 'dct_references_s': '{"http://schema.org/url": "https://mit.primo.exlibrisgroup.com/permalink/01MIT_INST/jp08pj/alma990022897960106761"}',
 'dcat_bbox': 'ENVELOPE(50.55, 50.55, 26.02750000, 26.02750000)',
 'gbl_suppressed_b': False,
 'locn_geometry': 'POINT(50.55, 26.02750000)',
 'schema_provider_s': 'MIT Libraries'}
"""
```
  * Note that `locn_geometry` has a WKT `POINT`
    * many MARC records define a POINT via the `034` tag where the West/East and North/South coordinates are the same, which allows setting this more specific WKT type
    * may need to revisit if the `dcat_bbox` `ENVELOPE` value is helpful in Opensearch when West/East and North/South points are the same, but believed to be technically valid at this point
  * Note `dct_references_s` is a link to Primo
    * some MARC records (~500) do have external links we could extract from `856` field; followup ticket will investigate if those are worth trying to include in `MITAardvark` record

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-227

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

