### PR TITLE
Prevent error logging for handled OGM harvest errors

### DIFF
--- a/harvester/harvest/__init__.py
+++ b/harvester/harvest/__init__.py
@@ -162,7 +162,7 @@ class Harvester(ABC):
                 }
                 self.failed_records.append(failure_dict)
                 message = f"Record error: {failure_dict}"
-                logger.error(message)
+                logger.debug(message)
             else:
                 yield record
 

--- a/harvester/records/exceptions.py
+++ b/harvester/records/exceptions.py
@@ -60,3 +60,12 @@ class JSONSchemaValidationError(ValidationError):
         return "\n".join(
             ["The normalized MITAardvark record is invalid:", *error_messages]
         )
+
+
+class NoExternalUrlError(Exception):
+    """Exception to raise when external URL cannot be determined from OGM record."""
+
+    def __init__(
+        self, message: str = "Could not determine external URL from source metadata"
+    ) -> None:
+        super().__init__(message)

--- a/harvester/records/formats/gbl1.py
+++ b/harvester/records/formats/gbl1.py
@@ -27,7 +27,12 @@ class GBL1(JSONSourceRecord):
     ##########################
 
     def _dct_accessRights_s(self) -> str:
-        return self.parsed_data["dc_rights_s"]
+        """Field method: dct_accessRights_s.
+
+        While dc_rights_s is a required GBL1 field, some OGM records do not have values.
+        In these scenarios, default to value "Public" for this required Aardvark field.
+        """
+        return self.parsed_data.get("dc_rights_s", "Public")
 
     def _dct_title_s(self) -> str | None:
         return self.parsed_data["dc_title_s"]

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -342,11 +342,11 @@ class SourceRecord:
             if field_method := getattr(self, f"_{aardvark_field.name}", None):
                 try:
                     all_field_values[aardvark_field.name] = field_method()
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     message = (
                         f"Error getting value for field '{aardvark_field.name}': {exc}"
                     )
-                    logger.exception(message)
+                    logger.debug(message)
                     raise FieldMethodError(exc, message) from exc
 
         # post normalization quality improvements

--- a/harvester/records/sources/ogm.py
+++ b/harvester/records/sources/ogm.py
@@ -8,6 +8,7 @@ from attrs import define, field
 
 from harvester.config import Config
 from harvester.records import SourceRecord
+from harvester.records.exceptions import NoExternalUrlError
 from harvester.records.formats import FGDC, GBL1, ISO19139, Aardvark
 
 logger = logging.getLogger(__name__)
@@ -68,8 +69,7 @@ class OGMGBL1(OGMSourceRecord, GBL1):
             refs_dict = json.loads(self.parsed_data["dct_references_s"])
             url = refs_dict.get("http://schema.org/url")
         if not url:
-            error_message = "Could not determine external URL from source metadata"
-            raise ValueError(error_message)
+            raise NoExternalUrlError
         urls_dict = {"http://schema.org/url": url}
 
         # extract optional download url
@@ -133,8 +133,7 @@ class OGMAardvark(OGMSourceRecord, Aardvark):
         # extract required external URL
         url = refs_dict.get("http://schema.org/url")
         if not url:
-            error_message = "Could not determine external URL from source metadata"
-            raise ValueError(error_message)
+            raise NoExternalUrlError
         urls_dict = {"http://schema.org/url": url}
 
         # extract optional download url

--- a/tests/test_records/test_aardvark.py
+++ b/tests/test_records/test_aardvark.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from harvester.records.exceptions import NoExternalUrlError
+
 
 def test_aardvark_required_dct_accessRights_s(aardvark_all_fields):
     assert aardvark_all_fields._dct_accessRights_s() == "Restricted"
@@ -52,7 +54,7 @@ def test_aardvark_required_dct_references_s(aardvark_all_fields):
 def test_aardvark_required_dct_references_s_no_url_raise_error(aardvark_all_fields):
     aardvark_all_fields._parsed_data = {"dct_references_s": "{}"}
     with pytest.raises(
-        ValueError, match="Could not determine external URL from source metadata"
+        NoExternalUrlError, match="Could not determine external URL from source metadata"
     ):
         aardvark_all_fields._dct_references_s()
 

--- a/tests/test_records/test_gbl1.py
+++ b/tests/test_records/test_gbl1.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from harvester.records.exceptions import NoExternalUrlError
+
 
 def test_gbl1_convert_scalar_to_array_no_value_get_list(gbl1_all_fields):
     assert gbl1_all_fields._convert_scalar_to_array("watermelon") == []
@@ -184,7 +186,7 @@ def test_gbl1_alternate_url_strategy_field_value_non_url_return_none(gbl1_all_fi
         "gbl1_field": "layer_slug_s",
     }
     with pytest.raises(
-        ValueError, match="Could not determine external URL from source metadata"
+        NoExternalUrlError, match="Could not determine external URL from source metadata"
     ):
         json.loads(gbl1_all_fields._dct_references_s())
 


### PR DESCRIPTION
### Purpose and background context

A recent harvest of `gismit` and `gisogm` in Stage environment resulted in 300+ Sentry errors.  These were thrown during record normalization for one of two scenarios:

- `GBL1` transformer attempted to access _should be_ required field `dc_rights_s`
- `OGMSourceRecord` attempted to build external URL from source record but failed

In both scenarios, while the record _did_ fail, it's a handled situation where the OGM data is not sufficient for our purposes.  In these cases, we should log the failed record as a `debug` statement, but it does not need to be an `error` or `exception` logging event.

The final logging statement for all runs is a dictionary:
```python
{
    "processed_records_count": self.processed_records_count,
    "successful_records": len(self.successful_records),
    "failed_records_count": len(self.failed_records),
    "failed_step_and_reason_count": self.get_harvest_failure_error_counts,
}
```

Where the key `failed_step_and_reason_count` has a breakdown of error type and count.  This alone should be sufficient for a quick glance at why records failed, and more thorough analysis could be done then.

### How can a reviewer manually see the effects of these changes?

Run an OGM harvest for a couple of repositories that threw errors in Sentry:
```shell
pipenv run harvester \
harvest -t full -o "output/ogm_error_handling.jsonl" \
ogm \
--include-repositories="edu.harvard,edu.berkeley"
```

Note that no `error` logging messages during run (run can take 4-5 minutes, as `edu.harvard` has lots of records).

Note the final logged results show a concise explanation of errors + counts, but there were not `error` logging statements:
```python
{'processed_records_count': 13386,
 'successful_records': 11994,
 'failed_records_count': 1392,
 'failed_step_and_reason_count': defaultdict(int,
             {"normalize_source_records: Error getting value for field 'dct_title_s': 'dc_title_s'": 1326,
              "normalize_source_records: Error getting value for field 'dct_references_s': Could not determine external URL from source metadata": 66})}
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: less logging in Sentry

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

