### PR TITLE
GDT 267 - Exit harvest early if no records

### DIFF
--- a/harvester/harvest/__init__.py
+++ b/harvester/harvest/__init__.py
@@ -55,6 +55,8 @@ class Harvester(ABC):
         try:
             first_record = next(records)
         except StopIteration:
+            message = "No source records found for harvest parameters, exiting."
+            logger.info(message)
             return self.harvest_stats
         records = chain([first_record], records)
 

--- a/tests/test_harvest/test_harvester.py
+++ b/tests/test_harvest/test_harvester.py
@@ -203,7 +203,7 @@ def test_harvester_step_write_combined_normalized_write_error_log_and_continue(
 
 
 def test_harvester_get_source_records_two_records_pipeline_completes(
-    caplog, generic_harvester_class, records_for_writing
+    generic_harvester_class, records_for_writing
 ):
     output_file = "output/combined_normalized.jsonl"
     harvester = generic_harvester_class(harvest_type="full", output_file=output_file)
@@ -216,6 +216,7 @@ def test_harvester_get_source_records_two_records_pipeline_completes(
 def test_harvester_get_source_records_empty_iterator_graceful_exit_early(
     caplog, generic_harvester_class
 ):
+    caplog.set_level("INFO")
     output_file = "output/combined_normalized.jsonl"
     harvester = generic_harvester_class(harvest_type="full", output_file=output_file)
     with patch.object(harvester, "get_source_records") as mocked_get_source_records:
@@ -225,3 +226,4 @@ def test_harvester_get_source_records_empty_iterator_graceful_exit_early(
         ) as mocked_normalize_records:
             _result = harvester.harvest()
             mocked_normalize_records.assert_not_called()
+    assert "No source records found for harvest parameters, exiting." in caplog.text


### PR DESCRIPTION
### Purpose and background context

This PR updates the GeoHarvester to exit early if there are no source records discovered.

Before this change, if no records were discovered for harvesting, the full pipeline of steps were still executed, just with an empty iterator.  For the most part this was inconsequential, except that an empty output file was still created for the normalized MIT Aardvark records.  This was problematic for Transmogrifier which had an empty file to work with.

Ignoring for the moment that Transmog and the TIMDEX pipeline might benefit from some empty / corrupt file handling, there is no reason why this harvester should create an empty file if it's easy to catch and exit early.  This mirrors the behavior of the OAI-PMH harvester which also will not create an empty output file if no records found during harvest.

### How can a reviewer manually see the effects of these changes?

Set Dev1 `TimdexManagers` AWS credentials.

Set MIT harvest env vars:
```shell
WORKSPACE=dev
SENTRY_DSN=None
S3_RESTRICTED_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/restricted/
S3_PUBLIC_CDN_ROOT=s3://cdn-origin-dev-222053980223/cdn/geo/public/
GEOHARVESTER_SQS_TOPIC_NAME=geo-harvester-input-dev
```

Run incremental MIT harvest (assuming the SQS queue is empty), which should find zero records for harvest:
```shell
pipenv run harvester --verbose harvest -t incremental -o output/mit_daily.jsonl mit
```

Note the following:
- `No source records found for harvest parameters, exiting.` in console logs
- file `output/mit_daily.jsonl` is not created

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-267

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

