### PR TITLE
Save only record fields required for EventBridge events

### DIFF
--- a/tests/test_harvest/test_mit_harvester.py
+++ b/tests/test_harvest/test_mit_harvester.py
@@ -277,6 +277,7 @@ def test_mit_harvester_send_eventbridge_duplicate_record_sends_one_last_event(
                 ),
             )
         )
+
     with mock.patch.object(
         MITHarvester,
         "_prepare_payload_and_send_event",
@@ -289,7 +290,7 @@ def test_mit_harvester_send_eventbridge_duplicate_record_sends_one_last_event(
         _output_records = list(harvester.send_eventbridge_event(iter(records)))
 
     mock_method.assert_called_once()
-    assert mock_method.mock_calls[0].args[2].source_record.event == "created"
+    assert not mock_method.mock_calls[0].args[2]["source_record_is_deleted"]
 
 
 def test_mit_harvester_send_eventbridge_multiples_records_send_multiple_events(
@@ -341,7 +342,13 @@ def test_mit_harvester_prepare_payload_and_send_event_success(records_for_mit_st
         harvester._prepare_payload_and_send_event(
             "the-bucket",
             "/path/here",
-            record,
+            record={
+                "record_identifier": record.identifier,
+                "source_record_is_restricted": record.source_record.is_restricted,
+                "source_record_is_deleted": record.source_record.is_deleted,
+                "source_metadata_filename": record.source_record.source_metadata_filename,
+                "normalized_metadata_filename": record.source_record.normalized_metadata_filename,  # noqa: E501
+            },
         )
         mocked_send_event.assert_called_with(
             detail={


### PR DESCRIPTION
### Purpose and background context
A recent full harvest of `gismit` by the GeoHarvester via the TIMDEX StepFunction failed because the ECS container ran out of memory. We ran into the same error before as described and addressed via https://github.com/MITLibraries/geo-harvester/pull/112. 

### How can a reviewer manually see the effects of these changes?
1. Review [successful StepFunction execution of `gismit` full harvest](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:14de71d8-919f-47b4-85c1-50a6870b01ef).
2. Review comparison of [performance metrics from Container insights](https://mitlibraries.atlassian.net/browse/GDT-323?focusedCommentId=130279).

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-323
### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

