### PR TITLE
GDT 329 - Skip suppressed OGM records during harvest

### DIFF
--- a/harvester/records/formats/aardvark.py
+++ b/harvester/records/formats/aardvark.py
@@ -16,6 +16,10 @@ class Aardvark(JSONSourceRecord):
 
     metadata_format: Literal["aardvark"] = field(default="aardvark")
 
+    @property
+    def is_suppressed(self) -> bool | None:
+        return self.parsed_data.get("gbl_suppressed_b")
+
     ##########################
     # Required Field Methods
     ##########################

--- a/harvester/records/formats/gbl1.py
+++ b/harvester/records/formats/gbl1.py
@@ -16,6 +16,10 @@ class GBL1(JSONSourceRecord):
 
     metadata_format: Literal["gbl1"] = field(default="gbl1")
 
+    @property
+    def is_suppressed(self) -> bool | None:
+        return self.parsed_data.get("suppressed_b")
+
     def _convert_scalar_to_array(self, field_name: str) -> list[str]:
         """Convert a single, scalar GBL1 value to Aardvark array."""
         if value := self.parsed_data.get(field_name):

--- a/harvester/records/record.py
+++ b/harvester/records/record.py
@@ -219,6 +219,11 @@ class SourceRecord:
             return True
         return False
 
+    @property
+    def is_suppressed(self) -> bool | None:
+        """Property to indicate if source record self-identified as suppressed."""
+        return False
+
     def get_controlled_dct_format_s_term(self, value: str | None) -> str | None:
         """Get a single controlled term for dct_format_s from original value.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -586,10 +586,9 @@ def ogm_incremental_harvester():
 
 @pytest.fixture
 def ogm_full_record_set():
+    """Full set of identifiers after suppressed and invalid records skipped."""
     return {
-        "edu.earth:5f5ac295b365",
         "edu.earth:3072f18cdeb5",
-        "edu.venus:996864ca615e",
         "edu.venus:7fe1e637995f",
         "edu.pluto:83509b6d7e03",
         "edu.pluto:83fd37f6a879",

--- a/tests/fixtures/ogm/files/edu.earth/record2.json
+++ b/tests/fixtures/ogm/files/edu.earth/record2.json
@@ -28,5 +28,6 @@
     "layer_modified_dt": "2012-11-28T23:35:27.343Z", 
     "layer_slug_s": "ark28722-s70026", 
     "solr_geom": "ENVELOPE(-122.653308, -122.18269, 38.674384, 38.148358)", 
-    "solr_year_i": 2010
+    "solr_year_i": 2010,
+    "suppressed_b": true
 }

--- a/tests/fixtures/ogm/files/edu.venus/record2.json
+++ b/tests/fixtures/ogm/files/edu.venus/record2.json
@@ -54,5 +54,6 @@
     "39015091195514_01"
   ],
   "gbl_mdModified_dt": "2023-02-03T21:22:59Z",
-  "gbl_mdVersion_s": "Aardvark"
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": true
 }

--- a/tests/test_harvest/test_ogm_harvester.py
+++ b/tests/test_harvest/test_ogm_harvester.py
@@ -209,7 +209,7 @@ def test_ogm_record_read_from_git_history(ogm_record_from_git_history):
 
 def test_ogm_harvester_get_full_source_records(ogm_full_harvester, ogm_full_record_set):
     records = list(ogm_full_harvester.get_source_records())
-    assert len(records) == 6
+    assert len(records) == 4
     assert {record.identifier for record in records} == ogm_full_record_set
 
 
@@ -218,7 +218,7 @@ def test_ogm_harvester_get_incremental_source_records_early_date(
 ):
     ogm_incremental_harvester.from_date = "1995-01-01"
     records = list(ogm_incremental_harvester.get_source_records())
-    assert len(records) == 6
+    assert len(records) == 4
     assert {record.identifier for record in records} == ogm_full_record_set
 
 


### PR DESCRIPTION
### Purpose and background context

This PR allows the `OGMHarvester` to skip OGM records that self-identify as suppressed, meaning GBL1 records have `suppressed_b=true` or Aardvark records have `gbl_suppressed_b=true`.

By surfacing this data point during `OGMHarvester` looping through source records to include for harvest, they can be easily skipped, and therefore not returned by the harvester.

### How can a reviewer manually see the effects of these changes?

Difficult to test with real data, but updated tests do a decent job at demonstrating.  Two files have been given a `suppressed=true` value:
- [tests/fixtures/ogm/files/edu.earth/record2.json](https://github.com/MITLibraries/geo-harvester/pull/315/files#diff-149e699a08474783d5c30a9fa00ba16a2f60d6195e87dc855c1a4b78d253bcf9)
- [tests/fixtures/ogm/files/edu.venus/record2.json](https://github.com/MITLibraries/geo-harvester/pull/315/files#diff-e588c5b24fcb981c4d990149a5d18fb08db5d7ca0b9252622b0f0eab60ffc34b)

In the test suite for `OGMHarvester`, we can see that successfully harvested records has dropped from 6 to 4.  Other records that do not have these fields at all, continue as normal; the `OGMHarvester` only looks for an explicit `suppressed=true` value to skip.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-329

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

